### PR TITLE
Move CloudTrail resources from idp-in-a-box to here and tweak slightly

### DIFF
--- a/aws/cloudtrail/README.md
+++ b/aws/cloudtrail/README.md
@@ -1,0 +1,33 @@
+# aws/cloudtrail - CloudTrail
+This module is used to set up CloudTrail logging for your AWS account.
+
+## What this does
+
+ - Create S3 bucket for CloudTrail logs
+ - Create IAM user with read-only access to CloudTrail S3 bucket
+ - Enable CloudTrail logging
+
+## Required Inputs
+
+- `s3_bucket_name` - The name for the S3 bucket where your CloudTrail logs will be stored
+
+## Optional Inputs
+
+- `cloudtrail_name` - The name for your Trail in AWS CloudTrail
+
+## Outputs
+
+ - `cloudtrail_access_key_id` - Access key for IAM user with read-only access to CloudTrail S3 bucket
+ - `cloudtrail_access_key_secret` - Secret access key
+ - `cloudtrail_arn` - ARN for CloudTrail S3 bucket
+ - `cloudtrail_username` - IAM username of read-only user to CloudTrail S3 bucket
+
+## Example Usage
+
+```hcl
+module "cloudtrail" {
+  source          = "github.com/silinternational/terraform-modules//aws/cloudtrail"
+  cloudtrail_name = "${var.cloudtrail_name}"
+  s3_bucket_name  = "YOUR-AWS-ACCOUNT-cloudtrail-logs"
+}
+```

--- a/aws/cloudtrail/main.tf
+++ b/aws/cloudtrail/main.tf
@@ -1,0 +1,75 @@
+resource "aws_s3_bucket" "cloudtrail" {
+  bucket        = "${var.s3_bucket_name}"
+  force_destroy = true
+
+  policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AWSCloudTrailAclCheck",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "cloudtrail.amazonaws.com"
+            },
+            "Action": "s3:GetBucketAcl",
+            "Resource": "arn:aws:s3:::${var.s3_bucket_name}"
+        },
+        {
+            "Sid": "AWSCloudTrailWrite",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "cloudtrail.amazonaws.com"
+            },
+            "Action": "s3:PutObject",
+            "Resource": "arn:aws:s3:::${var.s3_bucket_name}/*",
+            "Condition": {
+                "StringEquals": {
+                    "s3:x-amz-acl": "bucket-owner-full-control"
+                }
+            }
+        }
+    ]
+}
+POLICY
+}
+
+resource "aws_iam_user" "cloudtrail-s3" {
+  name = "cloudtrail-s3-${var.s3_bucket_name}"
+}
+
+resource "aws_iam_access_key" "cloudtrail-s3" {
+  user = "${aws_iam_user.cloudtrail-s3.name}"
+}
+
+resource "aws_iam_user_policy" "cloudtrail-s3" {
+  name = "cloudtrail-s3"
+  user = "${aws_iam_user.cloudtrail-s3.name}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetBucketPolicy",
+        "s3:GetObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+          "${aws_s3_bucket.cloudtrail.arn}",
+          "${aws_s3_bucket.cloudtrail.arn}/*"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_cloudtrail" "cloudtrail" {
+  count                         = 1
+  name                          = "${var.cloudtrail_name}"
+  s3_bucket_name                = "${aws_s3_bucket.cloudtrail.id}"
+  include_global_service_events = true
+}

--- a/aws/cloudtrail/outputs.tf
+++ b/aws/cloudtrail/outputs.tf
@@ -1,0 +1,15 @@
+output "cloudtrail_access_key_id" {
+  value = "${aws_iam_access_key.cloudtrail-s3.id}"
+}
+
+output "cloudtrail_access_key_secret" {
+  value = "${aws_iam_access_key.cloudtrail-s3.secret}"
+}
+
+output "cloudtrail_arn" {
+  value = "${aws_iam_user.cloudtrail-s3.arn}"
+}
+
+output "cloudtrail_username" {
+  value = "${aws_iam_user.cloudtrail-s3.name}"
+}

--- a/aws/cloudtrail/vars.tf
+++ b/aws/cloudtrail/vars.tf
@@ -1,0 +1,10 @@
+variable "cloudtrail_name" {
+  default     = "aws-account-cloudtrail"
+  description = "The name for your Trail in AWS CloudTrail"
+  type        = "string"
+}
+
+variable "s3_bucket_name" {
+  description = "The name for the S3 bucket where your CloudTrail logs will be stored"
+  type        = "string"
+}


### PR DESCRIPTION
Hi @fillup - Here's my attempt at moving that CloudTrail stuff from Idp-in-a-Box to here in our Terraform Modules repo. Since it's not specific to an IdP any more, I change the variables from things like `app_name` and `app_env` to `cloudtrail_name` and `s3_bucket_name`.