### PR TITLE
Allow optional user-specified command in AWS EC2 user_data

### DIFF
--- a/aws/asg-efs/README.md
+++ b/aws/asg-efs/README.md
@@ -25,6 +25,7 @@ an auto scaling group that uses the configuration.  An EFS file system is mounte
  - `key_name` - Name of the AWS key pair to allow ssh access, default is ""
  - `additional_security_groups` - List of additional security groups (in addition to default vpc security group)
  - `associate_public_ip_address` - true/false - Whether or not to associate public ip addresses with instances. Default: false
+ - `additional_user_data` - command to append to the EC2 user\_data, default is ""
 
 ## Outputs
 
@@ -46,5 +47,6 @@ module "asg" {
   ami_id = "${module.ecs.ami_id}"
   efs_dns_name = "${aws_efs_file_system.myfiles.dns_name}"
   mount_point = "/mnt/efs"
+  additional_user_data = "yum install -y something-interesting"
 }
 ```

--- a/aws/asg-efs/README.md
+++ b/aws/asg-efs/README.md
@@ -25,6 +25,7 @@ an auto scaling group that uses the configuration.  An EFS file system is mounte
  - `key_name` - Name of the AWS key pair to allow ssh access, default is ""
  - `additional_security_groups` - List of additional security groups (in addition to default vpc security group)
  - `associate_public_ip_address` - true/false - Whether or not to associate public ip addresses with instances. Default: false
+ - `startup_delay` - Seconds to wait for the yum repositories to become available. The user\_data script installs the nfs-utils package from the Amazon repositories which are located on S3. Default: 1 second
 
 ## Outputs
 

--- a/aws/asg-efs/README.md
+++ b/aws/asg-efs/README.md
@@ -25,7 +25,6 @@ an auto scaling group that uses the configuration.  An EFS file system is mounte
  - `key_name` - Name of the AWS key pair to allow ssh access, default is ""
  - `additional_security_groups` - List of additional security groups (in addition to default vpc security group)
  - `associate_public_ip_address` - true/false - Whether or not to associate public ip addresses with instances. Default: false
- - `startup_delay` - Seconds to wait for the yum repositories to become available. The user\_data script installs the nfs-utils package from the Amazon repositories which are located on S3. Default: 1 second
 
 ## Outputs
 

--- a/aws/asg-efs/main.tf
+++ b/aws/asg-efs/main.tf
@@ -8,7 +8,6 @@ data "template_file" "user_data" {
     ecs_cluster_name = "${var.ecs_cluster_name}"
     efs_dns_name     = "${var.efs_dns_name}"
     mount_point      = "${var.mount_point}"
-    startup_delay    = "${var.startup_delay}"
   }
 }
 

--- a/aws/asg-efs/main.tf
+++ b/aws/asg-efs/main.tf
@@ -8,6 +8,7 @@ data "template_file" "user_data" {
     ecs_cluster_name = "${var.ecs_cluster_name}"
     efs_dns_name     = "${var.efs_dns_name}"
     mount_point      = "${var.mount_point}"
+    startup_delay    = "${var.startup_delay}"
   }
 }
 

--- a/aws/asg-efs/main.tf
+++ b/aws/asg-efs/main.tf
@@ -5,9 +5,10 @@ data "template_file" "user_data" {
   template = "${file("${path.module}/user-data.sh")}"
 
   vars {
-    ecs_cluster_name = "${var.ecs_cluster_name}"
-    efs_dns_name     = "${var.efs_dns_name}"
-    mount_point      = "${var.mount_point}"
+    ecs_cluster_name     = "${var.ecs_cluster_name}"
+    efs_dns_name         = "${var.efs_dns_name}"
+    mount_point          = "${var.mount_point}"
+    additional_user_data = "${var.additional_user_data}"
   }
 }
 

--- a/aws/asg-efs/user-data.sh
+++ b/aws/asg-efs/user-data.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 echo ECS_CLUSTER=${ecs_cluster_name} >> /etc/ecs/ecs.config
 
+sleep ${startup_delay}
+
 # Install the NFS client utilities
 yum install -y nfs-utils
 

--- a/aws/asg-efs/user-data.sh
+++ b/aws/asg-efs/user-data.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 echo ECS_CLUSTER=${ecs_cluster_name} >> /etc/ecs/ecs.config
 
-sleep ${startup_delay}
-
 # Install the NFS client utilities
 yum install -y nfs-utils
 

--- a/aws/asg-efs/user-data.sh
+++ b/aws/asg-efs/user-data.sh
@@ -8,3 +8,6 @@ yum install -y nfs-utils
 mkdir -p ${mount_point}
 echo "${efs_dns_name}:/ ${mount_point} nfs4 nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,auto 0 0" >> /etc/fstab
 mount -a
+
+# Execute optional command supplied by user.
+${additional_user_data}

--- a/aws/asg-efs/vars.tf
+++ b/aws/asg-efs/vars.tf
@@ -66,3 +66,9 @@ variable "mount_point" {
   type    = "string"
   default = ""
 }
+
+variable "additional_user_data" {
+  type        = "string"
+  description = "Shell command to append to the EC2 user_data"
+  default     = ""
+}

--- a/aws/asg-efs/vars.tf
+++ b/aws/asg-efs/vars.tf
@@ -66,8 +66,3 @@ variable "mount_point" {
   type    = "string"
   default = ""
 }
-
-variable "startup_delay" {
-  type    = "string"
-  default = "1"
-}

--- a/aws/asg-efs/vars.tf
+++ b/aws/asg-efs/vars.tf
@@ -66,3 +66,8 @@ variable "mount_point" {
   type    = "string"
   default = ""
 }
+
+variable "startup_delay" {
+  type    = "string"
+  default = "1"
+}

--- a/aws/asg/README.md
+++ b/aws/asg/README.md
@@ -23,6 +23,7 @@ an auto scaling group that uses the configuration.
  - `key_name` - Name of the AWS key pair to allow ssh access, default is ""
  - `additional_security_groups` - List of additional security groups (in addition to default vpc security group)
  - `associate_public_ip_address` - true/false - Whether or not to associate public ip addresses with instances. Default: false
+ - `additional_user_data` - command to append to the EC2 user\_data, default is ""
 
 ## Outputs
 
@@ -42,5 +43,6 @@ module "asg" {
   ecs_instance_profile_id = "${module.ecs.ecs_instance_profile_id}"
   ecs_cluster_name = "${module.ecs.ecs_cluster_name}"
   ami_id = "${module.ecs.ami_id}"
+  additional_user_data = "yum install -y something-interesting"
 }
 ```

--- a/aws/asg/main.tf
+++ b/aws/asg/main.tf
@@ -6,6 +6,7 @@ data "template_file" "user_data" {
 
   vars {
     ecs_cluster_name = "${var.ecs_cluster_name}"
+    additional_user_data = "${var.additional_user_data}"
   }
 }
 

--- a/aws/asg/user-data.sh
+++ b/aws/asg/user-data.sh
@@ -1,2 +1,5 @@
 #!/bin/bash
 echo ECS_CLUSTER=${ecs_cluster_name} >> /etc/ecs/ecs.config
+
+# Execute optional command supplied by user.
+${additional_user_data}

--- a/aws/asg/vars.tf
+++ b/aws/asg/vars.tf
@@ -56,3 +56,9 @@ variable "additional_security_groups" {
   description = "A list of additional security groups to place instances into"
   default     = []
 }
+
+variable "additional_user_data" {
+  type        = "string"
+  description = "Shell command to append to the EC2 user_data"
+  default     = ""
+}


### PR DESCRIPTION
Please release this as version 2.6.0.  The additional parameter is optional and has a default value of an empty string (so no command will be added to the user_data).