### PR TITLE
Tie reference to cloudflare/ips to version 3.0.1

### DIFF
--- a/aws/cloudflare-sg/main.tf
+++ b/aws/cloudflare-sg/main.tf
@@ -1,5 +1,5 @@
 module "cf_ips" {
-  source = "github.com/silinternational/terraform-modules//cloudflare/ips"
+  source = "github.com/silinternational/terraform-modules//cloudflare/ips?ref=3.0.1"
 }
 
 resource "aws_security_group" "cloudflare_https" {


### PR DESCRIPTION
terraform-modules/aws/cloudflare-sg/main.tf referenced
terraform-modules/cloudflare/ips without specifying a version.
After the conversion of terraform-modules to Terraform 0.12,
Terraform 0.11 would attempt to load the latest version of the
module and fail due to the change in syntax for Terraform 0.12.
Specifying the version reference should prevent this in a future
breaking change to Terraform syntax.