### PR TITLE
Remove temporary EFS support from asg-ebs

### DIFF
--- a/aws/asg-ebs/README.md
+++ b/aws/asg-ebs/README.md
@@ -1,7 +1,6 @@
 # aws/asg-ebs - Auto Scaling Group with EBS mount
 This module is used to create an auto scaling group launch configuration and
 an auto scaling group that uses the configuration.  An EBS file system is mounted.
-During transition from EFS to EBS, an EFS file system is also mounted.
 
 ## What this does
 
@@ -21,19 +20,9 @@ During transition from EFS to EBS, an EFS file system is also mounted.
  - `default_sg_id` - VPC default security group ID to add instances to
  - `ecs_instance_profile_id` - IAM profile ID for ecsInstanceProfile
  - `ecs_cluster_name` - ECS cluster name for registering instances
- - `efs_dns_name` - DNS name of the EFS file system to be mounted
- - `mount_point` - Full path to directory on which to mount the EFS file system
-
-## Transitional Inputs
-
  - `ebs_device` - Device name for EBS volume, e.g., "/dev/sdh"
  - `ebs_mount_point` - Full path to directory on which to mount the file system contained in the EBS volume
  - `ebs_vol_id` - EBS volume ID
- - `ebs_mkfs_label` - Label for filesystem. Default: `Data`
- - `ebs_mkfs_labelflag` - Flag preceding the label name in the mkfs command. Default: `-L`
- - `ebs_mkfs_extraopts` - Extra options to pass to the mkfs command. Default: ""
- - `ebs_fs_type` - Type of filesystem to create. Default: `ext4`
- - `ebs_mountopts` - Mount options to include in /etc/fstab, default is "defaults,noatime"
 
 ## Optional Inputs
 
@@ -41,6 +30,11 @@ During transition from EFS to EBS, an EFS file system is also mounted.
  - `additional_security_groups` - List of additional security groups (in addition to default vpc security group)
  - `associate_public_ip_address` - true/false - Whether or not to associate public ip addresses with instances. Default: false
  - `additional_user_data` - command to append to the EC2 user\_data, default is ""
+ - `ebs_mkfs_label` - Label for filesystem. Default: `Data`
+ - `ebs_mkfs_labelflag` - Flag preceding the label name in the mkfs command. Default: `-L`
+ - `ebs_mkfs_extraopts` - Extra options to pass to the mkfs command. Default: ""
+ - `ebs_fs_type` - Type of filesystem to create. Default: `ext4`
+ - `ebs_mountopts` - Mount options to include in /etc/fstab, default is "defaults,noatime"
 
 ## Outputs
 
@@ -54,14 +48,15 @@ module "asg" {
   source = "github.com/silinternational/terraform-modules//aws/asg-ebs"
   app_name = var.app_name
   app_env = var.app_env
+  ami_id = module.ecs.ami_id
   aws_instance = var.aws_instance
+  aws_region = var.aws_region
+  aws_access_key = var.aws_access_key
+  aws_secret_key = var.aws_secret_key
   private_subnet_ids = [module.vpc.private_subnet_ids]
   default_sg_id = module.vpc.vpc_default_sg_id
   ecs_instance_profile_id = module.ecs.ecs_instance_profile_id
   ecs_cluster_name = module.ecs.ecs_cluster_name
-  ami_id = module.ecs.ami_id
-  efs_dns_name = aws_efs_file_system.myfiles.dns_name
-  mount_point = "/mnt/efs"
   additional_user_data = "yum install -y something-interesting"
   ebs_device = "/dev/sdh"
   ebs_mount_point = "/mnt/EBS"

--- a/aws/asg-ebs/README.md
+++ b/aws/asg-ebs/README.md
@@ -33,6 +33,7 @@ During transition from EFS to EBS, an EFS file system is also mounted.
  - `ebs_mkfs_labelflag` - Flag preceding the label name in the mkfs command. Default: `-L`
  - `ebs_mkfs_extraopts` - Extra options to pass to the mkfs command. Default: ""
  - `ebs_fs_type` - Type of filesystem to create. Default: `ext4`
+ - `ebs_mountopts` - Mount options to include in /etc/fstab, default is "defaults,noatime"
 
 ## Optional Inputs
 

--- a/aws/asg-ebs/main.tf
+++ b/aws/asg-ebs/main.tf
@@ -6,8 +6,6 @@ data "template_file" "user_data" {
 
   vars = {
     ecs_cluster_name     = var.ecs_cluster_name
-    efs_dns_name         = var.efs_dns_name
-    mount_point          = var.mount_point
     additional_user_data = var.additional_user_data
     aws_region           = var.aws_region
     aws_access_key       = var.aws_access_key

--- a/aws/asg-ebs/user-data.sh
+++ b/aws/asg-ebs/user-data.sh
@@ -1,17 +1,6 @@
 #!/bin/bash
 echo ECS_CLUSTER=${ecs_cluster_name} >> /etc/ecs/ecs.config
 
-# Install the NFS client utilities
-echo "user_data.sh: Installing nfs-utils"
-yum install -y nfs-utils
-
-# Mount the EFS file system
-echo "user_data.sh: Mounting EFS file system at ${mount_point}"
-mkdir -p ${mount_point}
-echo "${efs_dns_name}:/ ${mount_point} nfs4 nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,auto 0 0" >> /etc/fstab
-mount -a
-
-
 # Install the AWS CLI (needed to enable attaching the EBS volume)
 echo "user_data.sh: Installing the AWS CLI"
 yum install -y unzip

--- a/aws/asg-ebs/user-data.sh
+++ b/aws/asg-ebs/user-data.sh
@@ -31,8 +31,6 @@ echo "aws_secret_access_key = ${aws_secret_key}" >> ~/.aws/credentials
 
 
 # Get my EC2 instance ID
-# From https://stackoverflow.com/questions/625644/how-to-get-the-instance-id-from-within-an-ec2-instance
-# INSTANCE_ID=`curl http://169.254.169.254/latest/meta-data/instance-id`
 echo "user_data.sh: Getting EC2 instance ID"
 INSTANCE_ID=`ec2-metadata --instance-id | sed -e 's/.* //' | tr -d \\n`
 echo "user_data.sh: EC2 instance ID is $INSTANCE_ID"

--- a/aws/asg-ebs/vars.tf
+++ b/aws/asg-ebs/vars.tf
@@ -66,16 +66,6 @@ variable "additional_security_groups" {
   default     = []
 }
 
-variable "efs_dns_name" {
-  type    = string
-  default = ""
-}
-
-variable "mount_point" {
-  type    = string
-  default = ""
-}
-
 variable "additional_user_data" {
   type        = string
   description = "Shell command to append to the EC2 user_data"


### PR DESCRIPTION
Remove the temporary support for mounting EFS filesystem from module asg-ebs which should only support mounting a filesystem on EBS.

Release 3.4.0