### PR TITLE
ECR lifecycle policy

### DIFF
--- a/aws/ecr/ecr-lifecycle.json
+++ b/aws/ecr/ecr-lifecycle.json
@@ -1,0 +1,16 @@
+{
+  "rules": [
+    {
+      "rulePriority": 1,
+      "description": "Keep ${lifecycle_count} Lastest",
+      "selection": {
+        "tagStatus": "any",
+        "countType": "imageCountMoreThan",
+        "countNumber": ${lifecycle_count}
+      },
+      "action": {
+        "type": "expire"
+      }
+    }
+  ]
+}

--- a/aws/ecr/main.tf
+++ b/aws/ecr/main.tf
@@ -20,3 +20,15 @@ resource "aws_ecr_repository_policy" "policy" {
   policy     = data.template_file.repo_policy.rendered
 }
 
+data "template_file" "lifecycle" {
+  template = file("${path.module}/ecr-lifecycle.json")
+
+  vars = {
+    lifecycle_count = var.lifecycle_count
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "lifecycle" {
+   repository = aws_ecr_repository.repo.name
+   policy     = data.template_file.lifcycle.rendered
+}

--- a/aws/ecr/vars.tf
+++ b/aws/ecr/vars.tf
@@ -14,3 +14,7 @@ variable "cd_user_arn" {
   type = string
 }
 
+variable "lifecycle_count" {
+  type = string
+}
+


### PR DESCRIPTION
AWS ECR has lifecycle policy to control how many images are kept in the repository. I talked with @fillup and he thought using the count (rather than date) would be best.