### PR TITLE
use variable for ami filter and update default to amazon linux 2

### DIFF
--- a/aws/ecs/cluster/main.tf
+++ b/aws/ecs/cluster/main.tf
@@ -6,7 +6,7 @@ resource "aws_ecs_cluster" "ecs_cluster" {
 }
 
 /*
- * Deterimine most recent ECS optimized AMI
+ * Determine most recent ECS optimized AMI
  */
 data "aws_ami" "ecs_ami" {
   most_recent = true
@@ -14,7 +14,7 @@ data "aws_ami" "ecs_ami" {
 
   filter {
     name   = "name"
-    values = ["amzn-ami-*-amazon-ecs-optimized"]
+    values = [var.amiFilter]
   }
 }
 

--- a/aws/ecs/cluster/vars.tf
+++ b/aws/ecs/cluster/vars.tf
@@ -12,6 +12,11 @@ variable "app_env" {
 /*
  * Optional variables
  */
+variable "amiFilter" {
+  type    = string
+  default = "amzn2-ami-ecs-hvm-*-x86_64-ebs"
+}
+
 variable "ecsInstanceRoleAssumeRolePolicy" {
   type = string
 


### PR DESCRIPTION
we may want to consider this a BC breaking change, though it shouldn't make any difference to services running on the cluster and is working fine with one of our IdPs. 