### PR TITLE
use variable for ami filter in ecs/cluster and update default to amazon linux 2

### DIFF
--- a/aws/ecs/cluster/main.tf
+++ b/aws/ecs/cluster/main.tf
@@ -6,7 +6,7 @@ resource "aws_ecs_cluster" "ecs_cluster" {
 }
 
 /*
- * Deterimine most recent ECS optimized AMI
+ * Determine most recent ECS optimized AMI
  */
 data "aws_ami" "ecs_ami" {
   most_recent = true
@@ -14,7 +14,7 @@ data "aws_ami" "ecs_ami" {
 
   filter {
     name   = "name"
-    values = ["amzn-ami-*-amazon-ecs-optimized"]
+    values = [var.amiFilter]
   }
 }
 

--- a/aws/ecs/cluster/vars.tf
+++ b/aws/ecs/cluster/vars.tf
@@ -12,6 +12,11 @@ variable "app_env" {
 /*
  * Optional variables
  */
+variable "amiFilter" {
+  type    = string
+  default = "amzn2-ami-ecs-hvm-*-x86_64-ebs"
+}
+
 variable "ecsInstanceRoleAssumeRolePolicy" {
   type = string
 


### PR DESCRIPTION
Release as 4.0.0 to highlight "breaking change" of default AMI used in ecs/cluster is now Amazon Linux 2 instead of 1. 

The key change to be aware of us using Amazon Linux 2 requires a minimum EBS volume size of 30GB instead of 8GB. 