### PR TITLE
Release 6.0.0 - update providers

### DIFF
--- a/aws/alb/versions.tf
+++ b/aws/alb/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0.0, < 5.0.0"
+      version = ">= 4.0.0, < 5.0.0"
     }
   }
 }

--- a/aws/asg-ebs/versions.tf
+++ b/aws/asg-ebs/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0.0, < 5.0.0"
+      version = ">= 4.0.0, < 5.0.0"
     }
   }
 }

--- a/aws/asg-efs/versions.tf
+++ b/aws/asg-efs/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0.0, < 5.0.0"
+      version = ">= 4.0.0, < 5.0.0"
     }
   }
 }

--- a/aws/asg/versions.tf
+++ b/aws/asg/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0.0, < 5.0.0"
+      version = ">= 4.0.0, < 5.0.0"
     }
   }
 }

--- a/aws/backup/rds/versions.tf
+++ b/aws/backup/rds/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0.0, < 5.0.0"
+      version = ">= 4.0.0, < 5.0.0"
     }
   }
 }

--- a/aws/cloudflare-sg/versions.tf
+++ b/aws/cloudflare-sg/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0.0, < 5.0.0"
+      version = ">= 4.0.0, < 5.0.0"
     }
   }
 }

--- a/aws/cloudtrail/versions.tf
+++ b/aws/cloudtrail/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0.0, < 5.0.0"
+      version = ">= 4.0.0, < 5.0.0"
     }
   }
 }

--- a/aws/ecr/versions.tf
+++ b/aws/ecr/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0.0, < 5.0.0"
+      version = ">= 4.0.0, < 5.0.0"
     }
   }
 }

--- a/aws/ecs/cluster/versions.tf
+++ b/aws/ecs/cluster/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0.0, < 5.0.0"
+      version = ">= 4.0.0, < 5.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/aws/ecs/service-no-alb-with-volume/versions.tf
+++ b/aws/ecs/service-no-alb-with-volume/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0.0, < 5.0.0"
+      version = ">= 4.0.0, < 5.0.0"
     }
   }
 }

--- a/aws/ecs/service-no-alb/versions.tf
+++ b/aws/ecs/service-no-alb/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0.0, < 5.0.0"
+      version = ">= 4.0.0, < 5.0.0"
     }
   }
 }

--- a/aws/ecs/service-only-with-volume/versions.tf
+++ b/aws/ecs/service-only-with-volume/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0.0, < 5.0.0"
+      version = ">= 4.0.0, < 5.0.0"
     }
   }
 }

--- a/aws/ecs/service-only/versions.tf
+++ b/aws/ecs/service-only/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0.0, < 5.0.0"
+      version = ">= 4.0.0, < 5.0.0"
     }
   }
 }

--- a/aws/elasticache/memcache/versions.tf
+++ b/aws/elasticache/memcache/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0.0, < 5.0.0"
+      version = ">= 4.0.0, < 5.0.0"
     }
   }
 }

--- a/aws/elasticache/redis/versions.tf
+++ b/aws/elasticache/redis/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0.0, < 5.0.0"
+      version = ">= 4.0.0, < 5.0.0"
     }
   }
 }

--- a/aws/rds/mariadb/main.tf
+++ b/aws/rds/mariadb/main.tf
@@ -4,7 +4,7 @@ resource "aws_db_instance" "db_instance" {
   allocated_storage       = var.allocated_storage
   copy_tags_to_snapshot   = var.copy_tags_to_snapshot
   instance_class          = var.instance_class
-  name                    = var.db_name
+  db_name                 = var.db_name
   identifier              = "${var.app_name}-${var.app_env}"
   username                = var.db_root_user
   password                = var.db_root_pass

--- a/aws/rds/mariadb/versions.tf
+++ b/aws/rds/mariadb/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0.0, < 5.0.0"
+      version = ">= 4.0.0, < 5.0.0"
     }
   }
 }

--- a/aws/vpc-public-only/versions.tf
+++ b/aws/vpc-public-only/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0.0, < 5.0.0"
+      version = ">= 4.0.0, < 5.0.0"
     }
   }
 }

--- a/aws/vpc/versions.tf
+++ b/aws/vpc/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0.0, < 5.0.0"
+      version = ">= 4.0.0, < 5.0.0"
     }
   }
 }

--- a/cloudflare/ips/outputs.tf
+++ b/cloudflare/ips/outputs.tf
@@ -1,8 +1,7 @@
 output "ipv4_cidrs" {
-  value = split("\n", trimspace(data.http.cloudflare_ipv4.body))
+  value = split("\n", trimspace(data.http.cloudflare_ipv4.response_body))
 }
 
 output "ipv6_cidrs" {
-  value = split("\n", trimspace(data.http.cloudflare_ipv6.body))
+  value = split("\n", trimspace(data.http.cloudflare_ipv6.response_body))
 }
-

--- a/cloudflare/ips/versions.tf
+++ b/cloudflare/ips/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0.0, < 5.0.0"
+      version = ">= 4.0.0, < 5.0.0"
     }
     http = {
       source  = "hashicorp/http"

--- a/cloudflare/ips/versions.tf
+++ b/cloudflare/ips/versions.tf
@@ -9,7 +9,7 @@ terraform {
     }
     http = {
       source  = "hashicorp/http"
-      version = ">= 1.1.0, < 3.0.0"
+      version = ">= 2.0.0, < 3.0.0"
     }
   }
 }


### PR DESCRIPTION
### Fixed
- Changed usage of deprecated parameters, which required removal of earlier provider versions.
### Removed
- Removed support of aws provider versions 2.x and 3.x
- Removed support of http provider version 1.x