### PR TITLE
Convert from AWS Launch Configuration to Launch Template

### DIFF
--- a/aws/asg-ebs/README.md
+++ b/aws/asg-ebs/README.md
@@ -1,10 +1,10 @@
 # aws/asg-ebs - Auto Scaling Group with EBS mount
-This module is used to create an auto scaling group launch configuration and
-an auto scaling group that uses the configuration.  An EBS file system is mounted.
+This module is used to create an auto scaling group launch template and
+an auto scaling group that uses the template.  An EBS file system is mounted.
 
 ## What this does
 
- - Create launch configuration named after `app_name` and `app_env`
+ - Create launch template named after `app_name` and `app_env`
  - Create auto scaling group of defined size and distribute instances across `aws_zones`
 
 ## Required Inputs
@@ -27,6 +27,7 @@ an auto scaling group that uses the configuration.  An EBS file system is mounte
 ## Optional Inputs
 
  - `key_name` - Name of the AWS key pair to allow ssh access, default is ""
+ - `root_device_name` - Name of the root device for the EC2 instance. Default: `/dev/xvda`
  - `additional_security_groups` - List of additional security groups (in addition to default vpc security group)
  - `associate_public_ip_address` - true/false - Whether or not to associate public ip addresses with instances. Default: false
  - `additional_user_data` - command to append to the EC2 user\_data, default is ""
@@ -38,7 +39,7 @@ an auto scaling group that uses the configuration.  An EBS file system is mounte
 
 ## Outputs
 
- - `launch_configuration_id` - The launch configuration ID
+ - `launch_template_id` - The launch template ID
  - `auto_scaling_group_id` - ASG ID
 
 ## Example Usage

--- a/aws/asg-ebs/main.tf
+++ b/aws/asg-ebs/main.tf
@@ -29,7 +29,7 @@ resource "aws_launch_template" "asg_lt" {
   image_id        = var.ami_id
   instance_type   = var.aws_instance["instance_type"]
   key_name        = var.key_name
-  user_data       = local.user_data
+  user_data       = base64encode(local.user_data)
 
   block_device_mappings {
     device_name = var.root_device_name

--- a/aws/asg-ebs/main.tf
+++ b/aws/asg-ebs/main.tf
@@ -20,25 +20,36 @@ locals {
 }
 
 /*
- * Create Launch Configuration
+ * Create Launch Template
  */
-resource "aws_launch_configuration" "as_conf" {
-  name_prefix                 = "${var.app_name}-${var.app_env}-"
-  image_id                    = var.ami_id
-  instance_type               = var.aws_instance["instance_type"]
-  security_groups             = concat([var.default_sg_id], var.additional_security_groups)
-  iam_instance_profile        = var.ecs_instance_profile_id
-  key_name                    = var.key_name
-  associate_public_ip_address = var.associate_public_ip_address
+resource "aws_launch_template" "asg_lt" {
+  default_version = 1
+  ebs_optimized   = "false"
+  name            = "lt-${var.app_name}-${var.app_env}"
+  image_id        = var.ami_id
+  instance_type   = var.aws_instance["instance_type"]
+  key_name        = var.key_name
+  user_data       = local.user_data
 
-  root_block_device {
-    volume_size = var.aws_instance["volume_size"]
+  block_device_mappings {
+    device_name = var.root_device_name
+    ebs {
+      delete_on_termination = "true"
+      volume_size = var.aws_instance["volume_size"]
+    }
   }
 
-  user_data = local.user_data
+  network_interfaces {
+    associate_public_ip_address = var.associate_public_ip_address
+    security_groups             = concat([var.default_sg_id], var.additional_security_groups)
+  }
 
-  lifecycle {
-    create_before_destroy = true
+  iam_instance_profile {
+    name = var.ecs_instance_profile_id
+  }
+
+  monitoring {
+    enabled = true
   }
 }
 
@@ -51,13 +62,13 @@ resource "aws_autoscaling_group" "asg" {
   min_size                  = var.aws_instance["instance_count"]
   max_size                  = var.aws_instance["instance_count"]
   desired_capacity          = var.aws_instance["instance_count"]
-  launch_configuration      = aws_launch_configuration.as_conf.id
   health_check_type         = "EC2"
   health_check_grace_period = "120"
   default_cooldown          = "30"
 
-  lifecycle {
-    create_before_destroy = true
+  launch_template {
+    id      = aws_launch_template.asg_lt.id
+    version = "$Latest"
   }
 
   tag {

--- a/aws/asg-ebs/main.tf
+++ b/aws/asg-ebs/main.tf
@@ -24,7 +24,7 @@ locals {
  */
 resource "aws_launch_template" "asg_lt" {
   default_version = 1
-  ebs_optimized   = "false"
+  ebs_optimized   = false
   name            = "lt-${var.app_name}-${var.app_env}"
   image_id        = var.ami_id
   instance_type   = var.aws_instance["instance_type"]
@@ -34,8 +34,8 @@ resource "aws_launch_template" "asg_lt" {
   block_device_mappings {
     device_name = var.root_device_name
     ebs {
-      delete_on_termination = "true"
-      volume_size = var.aws_instance["volume_size"]
+      delete_on_termination = true
+      volume_size           = var.aws_instance["volume_size"]
     }
   }
 

--- a/aws/asg-ebs/outputs.tf
+++ b/aws/asg-ebs/outputs.tf
@@ -1,5 +1,5 @@
-output "launch_configuration_id" {
-  value = aws_launch_configuration.as_conf.id
+output "launch_template_id" {
+  value = aws_launch_template.asg_lt.id
 }
 
 output "auto_scaling_group_id" {

--- a/aws/asg-ebs/vars.tf
+++ b/aws/asg-ebs/vars.tf
@@ -36,6 +36,11 @@ variable "aws_instance" {
   }
 }
 
+variable "root_device_name" {
+  type    = string
+  default = "/dev/xvda"
+}
+
 variable "aws_region" {
 }
 

--- a/aws/asg-efs/README.md
+++ b/aws/asg-efs/README.md
@@ -1,10 +1,10 @@
 # aws/asg-efs - Auto Scaling Group with EFS mount
-This module is used to create an auto scaling group launch configuration and
-an auto scaling group that uses the configuration.  An EFS file system is mounted.
+This module is used to create an auto scaling group launch template and
+an auto scaling group that uses the template.  An EFS file system is mounted.
 
 ## What this does
 
- - Create launch configuration named after `app_name` and `app_env`
+ - Create launch template named after `app_name` and `app_env`
  - Create auto scaling group of defined size and distribute instances across `aws_zones`
 
 ## Required Inputs
@@ -23,13 +23,14 @@ an auto scaling group that uses the configuration.  An EFS file system is mounte
 ## Optional Inputs
 
  - `key_name` - Name of the AWS key pair to allow ssh access, default is ""
+ - `root_device_name` - Name of the root device for the EC2 instance. Default: `/dev/xvda`
  - `additional_security_groups` - List of additional security groups (in addition to default vpc security group)
  - `associate_public_ip_address` - true/false - Whether or not to associate public ip addresses with instances. Default: false
  - `additional_user_data` - command to append to the EC2 user\_data, default is ""
 
 ## Outputs
 
- - `launch_configuration_id` - The launch configuration ID
+ - `launch_template_id` - The launch template ID
  - `auto_scaling_group_id` - ASG ID
 
 ## Example Usage

--- a/aws/asg-efs/main.tf
+++ b/aws/asg-efs/main.tf
@@ -11,25 +11,36 @@ locals {
 }
 
 /*
- * Create Launch Configuration
+ * Create Launch Template
  */
-resource "aws_launch_configuration" "as_conf" {
-  name_prefix                 = "${var.app_name}-${var.app_env}-"
-  image_id                    = var.ami_id
-  instance_type               = var.aws_instance["instance_type"]
-  security_groups             = concat([var.default_sg_id], var.additional_security_groups)
-  iam_instance_profile        = var.ecs_instance_profile_id
-  key_name                    = var.key_name
-  associate_public_ip_address = var.associate_public_ip_address
+resource "aws_launch_template" "asg_lt" {
+  default_version = 1
+  ebs_optimized   = false
+  name            = "lt-${var.app_name}-${var.app_env}"
+  image_id        = var.ami_id
+  instance_type   = var.aws_instance["instance_type"]
+  key_name        = var.key_name
+  user_data       = base64encode(local.user_data)
 
-  root_block_device {
-    volume_size = var.aws_instance["volume_size"]
+  block_device_mappings {
+    device_name = var.root_device_name
+    ebs {
+      delete_on_termination = true
+      volume_size           = var.aws_instance["volume_size"]
+    }
   }
 
-  user_data = local.user_data
+  network_interfaces {
+    associate_public_ip_address = var.associate_public_ip_address
+    security_groups             = concat([var.default_sg_id], var.additional_security_groups)
+  }
 
-  lifecycle {
-    create_before_destroy = true
+  iam_instance_profile {
+    name = var.ecs_instance_profile_id
+  }
+
+  monitoring {
+    enabled = true
   }
 }
 
@@ -42,13 +53,13 @@ resource "aws_autoscaling_group" "asg" {
   min_size                  = var.aws_instance["instance_count"]
   max_size                  = var.aws_instance["instance_count"]
   desired_capacity          = var.aws_instance["instance_count"]
-  launch_configuration      = aws_launch_configuration.as_conf.id
   health_check_type         = "EC2"
   health_check_grace_period = "120"
   default_cooldown          = "30"
 
-  lifecycle {
-    create_before_destroy = true
+  launch_template {
+    id      = aws_launch_template.asg_lt.id
+    version = "$Latest"
   }
 
   tag {

--- a/aws/asg-efs/outputs.tf
+++ b/aws/asg-efs/outputs.tf
@@ -1,5 +1,5 @@
-output "launch_configuration_id" {
-  value = aws_launch_configuration.as_conf.id
+output "launch_template_id" {
+  value = aws_launch_template.asg_lt.id
 }
 
 output "auto_scaling_group_id" {

--- a/aws/asg-efs/vars.tf
+++ b/aws/asg-efs/vars.tf
@@ -30,6 +30,11 @@ variable "aws_instance" {
   }
 }
 
+variable "root_device_name" {
+  type    = string
+  default = "/dev/xvda"
+}
+
 variable "private_subnet_ids" {
   type = list(string)
 }

--- a/aws/asg/README.md
+++ b/aws/asg/README.md
@@ -1,10 +1,10 @@
 # aws/asg - Auto Scaling Group
-This module is used to create an auto scaling group launch configuration and
-an auto scaling group that uses the configuration.
+This module is used to create an auto scaling group launch template and
+an auto scaling group that uses the template.
 
 ## What this does
 
- - Create launch configuration named after `app_name` and `app_env`
+ - Create launch template named after `app_name` and `app_env`
  - Create auto scaling group of defined size and distribute instances across `aws_zones`
 
 ## Required Inputs
@@ -21,6 +21,7 @@ an auto scaling group that uses the configuration.
 ## Optional Inputs
 
  - `key_name` - Name of the AWS key pair to allow ssh access, default is ""
+ - `root_device_name` - Name of the root device for the EC2 instance. Default: `/dev/xvda`
  - `additional_security_groups` - List of additional security groups (in addition to default vpc security group)
  - `associate_public_ip_address` - true/false - Whether or not to associate public ip addresses with instances. Default: false
  - `additional_user_data` - command to append to the EC2 user\_data, default is ""
@@ -28,7 +29,7 @@ an auto scaling group that uses the configuration.
 
 ## Outputs
 
- - `launch_configuration_id` - The launch configuration ID
+ - `launch_template_id` - The launch template ID
  - `auto_scaling_group_id` - ASG ID
 
 ## Example Usage

--- a/aws/asg/main.tf
+++ b/aws/asg/main.tf
@@ -9,25 +9,36 @@ locals {
 }
 
 /*
- * Create Launch Configuration
+ * Create Launch Template
  */
-resource "aws_launch_configuration" "as_conf" {
-  name_prefix                 = "${var.app_name}-${var.app_env}-"
-  image_id                    = var.ami_id
-  instance_type               = var.aws_instance["instance_type"]
-  security_groups             = concat([var.default_sg_id], var.additional_security_groups)
-  iam_instance_profile        = var.ecs_instance_profile_id
-  key_name                    = var.key_name
-  associate_public_ip_address = var.associate_public_ip_address
+resource "aws_launch_template" "asg_lt" {
+  default_version = 1
+  ebs_optimized   = false
+  name            = "lt-${var.app_name}-${var.app_env}"
+  image_id        = var.ami_id
+  instance_type   = var.aws_instance["instance_type"]
+  key_name        = var.key_name
+  user_data       = base64encode(local.user_data)
 
-  root_block_device {
-    volume_size = var.aws_instance["volume_size"]
+  block_device_mappings {
+    device_name = var.root_device_name
+    ebs {
+      delete_on_termination = true
+      volume_size           = var.aws_instance["volume_size"]
+    }
   }
 
-  user_data = local.user_data
+  network_interfaces {
+    associate_public_ip_address = var.associate_public_ip_address
+    security_groups             = concat([var.default_sg_id], var.additional_security_groups)
+  }
 
-  lifecycle {
-    create_before_destroy = true
+  iam_instance_profile {
+    name = var.ecs_instance_profile_id
+  }
+
+  monitoring {
+    enabled = true
   }
 }
 
@@ -40,13 +51,13 @@ resource "aws_autoscaling_group" "asg" {
   min_size                  = var.aws_instance["instance_count"]
   max_size                  = var.aws_instance["instance_count"]
   desired_capacity          = var.aws_instance["instance_count"]
-  launch_configuration      = aws_launch_configuration.as_conf.id
   health_check_type         = "EC2"
   health_check_grace_period = "120"
   default_cooldown          = "30"
 
-  lifecycle {
-    create_before_destroy = true
+  launch_template {
+    id      = aws_launch_template.asg_lt.id
+    version = "$Latest"
   }
 
   tag {

--- a/aws/asg/outputs.tf
+++ b/aws/asg/outputs.tf
@@ -1,5 +1,5 @@
-output "launch_configuration_id" {
-  value = aws_launch_configuration.as_conf.id
+output "launch_template_id" {
+  value = aws_launch_template.asg_lt.id
 }
 
 output "auto_scaling_group_id" {

--- a/aws/asg/vars.tf
+++ b/aws/asg/vars.tf
@@ -30,6 +30,11 @@ variable "aws_instance" {
   }
 }
 
+variable "root_device_name" {
+  type    = string
+  default = "/dev/xvda"
+}
+
 variable "private_subnet_ids" {
   type = list(string)
 }


### PR DESCRIPTION
AWS has deprecated support for new Instances using Amazon EC2 Auto Scaling launch configurations.  Launch templates are the recommended replacement.

I have tested the changes in the asg-ebs module with an instance of JIRA.  I made similar changes in the asg and asg-efs modules.  As far as I know, we don't use asg-efs any longer.  It would be a good idea to test the changes with one or more of the many projects that use the asg module.