### PR TITLE
Add optional tags for ASG

### DIFF
--- a/aws/asg-ebs/README.md
+++ b/aws/asg-ebs/README.md
@@ -36,6 +36,7 @@ an auto scaling group that uses the template.  An EBS file system is mounted.
  - `ebs_mkfs_extraopts` - Extra options to pass to the mkfs command. Default: ""
  - `ebs_fs_type` - Type of filesystem to create. Default: `ext4`
  - `ebs_mountopts` - Mount options to include in /etc/fstab, default is "defaults,noatime"
+ - `tags` - A list of tag definitions in JSON format to be applied to the asg.
 
 ## Outputs
 
@@ -64,5 +65,13 @@ module "asg" {
   ebs_vol_id = aws_ebs_volume.bigvol.id
   ebs_mkfs_label = "MyBigFS"
   ebs_mkfs_extraopts = "-m 2 -i 32768"
+
+  tags = [
+    {
+      key                 = "foo"
+      value               = "bar"
+      propagate_at_launch = true
+    },
+  ]
 }
 ```

--- a/aws/asg-ebs/main.tf
+++ b/aws/asg-ebs/main.tf
@@ -88,5 +88,15 @@ resource "aws_autoscaling_group" "asg" {
     value               = var.app_env
     propagate_at_launch = true
   }
+
+  dynamic "tag" {
+    for_each = var.tags
+
+    content {
+      key                 = tag.value.key
+      value               = tag.value.value
+      propagate_at_launch = tag.value.propagate_at_launch
+    }
+  }
 }
 

--- a/aws/asg-ebs/vars.tf
+++ b/aws/asg-ebs/vars.tf
@@ -77,6 +77,12 @@ variable "additional_user_data" {
   default     = ""
 }
 
+variable "tags" {
+  type        = list(any)
+  description = "Additional tags to add to asg."
+  default     = []
+}
+
 variable "ebs_device" {
   type        = string
   default     = ""

--- a/aws/asg-efs/README.md
+++ b/aws/asg-efs/README.md
@@ -27,6 +27,7 @@ an auto scaling group that uses the template.  An EFS file system is mounted.
  - `additional_security_groups` - List of additional security groups (in addition to default vpc security group)
  - `associate_public_ip_address` - true/false - Whether or not to associate public ip addresses with instances. Default: false
  - `additional_user_data` - command to append to the EC2 user\_data, default is ""
+ - `tags` - A list of tag definitions in JSON format to be applied to the asg.
 
 ## Outputs
 
@@ -49,5 +50,13 @@ module "asg" {
   efs_dns_name = "${aws_efs_file_system.myfiles.dns_name}"
   mount_point = "/mnt/efs"
   additional_user_data = "yum install -y something-interesting"
+
+  tags = [
+    {
+      key                 = "foo"
+      value               = "bar"
+      propagate_at_launch = true
+    },
+  ]
 }
 ```

--- a/aws/asg-efs/main.tf
+++ b/aws/asg-efs/main.tf
@@ -79,5 +79,15 @@ resource "aws_autoscaling_group" "asg" {
     value               = var.app_env
     propagate_at_launch = true
   }
+
+  dynamic "tag" {
+    for_each = var.tags
+
+    content {
+      key                 = tag.value.key
+      value               = tag.value.value
+      propagate_at_launch = tag.value.propagate_at_launch
+    }
+  }
 }
 

--- a/aws/asg-efs/vars.tf
+++ b/aws/asg-efs/vars.tf
@@ -78,3 +78,8 @@ variable "additional_user_data" {
   default     = ""
 }
 
+variable "tags" {
+  type        = list(any)
+  description = "Additional tags to add to asg."
+  default     = []
+}


### PR DESCRIPTION
Add optional user-supplied tags functionality to asg-ebs and asg-efs that already existed in asg.  The "default_tags" block in the "aws" provider doesn't apply to the "aws_autoscaling_group" resource.  This change allows us to add the tags from the default_tags block to EC2 instances launched by the autoscaling group.