### PR TITLE
remove timestamp recovery_point_tag from backup module

### DIFF
--- a/aws/backup/rds/main.tf
+++ b/aws/backup/rds/main.tf
@@ -64,11 +64,6 @@ resource "aws_backup_plan" "bkup_plan" {
       cold_storage_after = 7   # a week in days
       delete_after       = 100 # must be at least 90 days more than cold_storage_after
     }
-
-    # Metadata you assign to help organize the resources that you create
-    recovery_point_tags = {
-      datetime = timestamp()
-    }
   }
 
   tags = {


### PR DESCRIPTION
### Fixed
- Remove extraneous recovery point tag set to the timestamp of the Terraform run.

_Note: this timestamp causes the state to be updated on every run. Since this seems like not a useful tag to have, it's better to remove it._