### PR TITLE
set vpc = true in creation of elastic IP for NAT gateway

### DIFF
--- a/aws/vpc/main.tf
+++ b/aws/vpc/main.tf
@@ -71,6 +71,7 @@ resource "aws_eip" "gateway_eip" {
     app_name = var.app_name
     app_env  = var.app_env
   }
+  vpc = true
 }
 
 resource "aws_nat_gateway" "nat_gateway" {


### PR DESCRIPTION
This is because of the retirement of EC2-Classic. Error message was "Error: with the retirement of EC2-Classic no new non-VPC EC2 EIPs can be created"