### PR TITLE
Release 8.0.0 - remove timestamp recovery_point_tag from aws/backup

### DIFF
--- a/aws/backup/rds/main.tf
+++ b/aws/backup/rds/main.tf
@@ -64,11 +64,6 @@ resource "aws_backup_plan" "bkup_plan" {
       cold_storage_after = 7   # a week in days
       delete_after       = 100 # must be at least 90 days more than cold_storage_after
     }
-
-    # Metadata you assign to help organize the resources that you create
-    recovery_point_tags = {
-      datetime = timestamp()
-    }
   }
 
   tags = {


### PR DESCRIPTION
### Changed (breaking)
- Remove timestamp recovery_point_tag from backup module because it causes the state to be updated on every run.