### PR TITLE
Tag objects created by launch template

### DIFF
--- a/aws/asg-ebs/README.md
+++ b/aws/asg-ebs/README.md
@@ -37,6 +37,7 @@ an auto scaling group that uses the template.  An EBS file system is mounted.
  - `ebs_fs_type` - Type of filesystem to create. Default: `ext4`
  - `ebs_mountopts` - Mount options to include in /etc/fstab, default is "defaults,noatime"
  - `tags` - A list of tag definitions to be applied to the asg. See example below.
+ - `lt_tags` - A map of tag definitions to be applied to the network interfaces and volumes created by the launch template. See example below.
 
 ## Outputs
 
@@ -73,5 +74,10 @@ module "asg" {
       propagate_at_launch = true
     },
   ]
+
+  lt_tags = {
+    tagname1 = "value1"
+    tagname2 = "value2"
+  }
 }
 ```

--- a/aws/asg-ebs/main.tf
+++ b/aws/asg-ebs/main.tf
@@ -51,6 +51,17 @@ resource "aws_launch_template" "asg_lt" {
   monitoring {
     enabled = true
   }
+
+  dynamic "tag_specifications" {
+    for_each = ["network-interface", "volume"]
+    iterator = resource
+
+    content {
+      resource_type = resource.value
+
+      tags = var.lt_tags
+    }
+  }
 }
 
 /*

--- a/aws/asg-ebs/vars.tf
+++ b/aws/asg-ebs/vars.tf
@@ -83,6 +83,12 @@ variable "tags" {
   default     = []
 }
 
+variable "lt_tags" {
+  type        = map(string)
+  description = "Map of tags to be added to network-interface and volume created by the launch template"
+  default     = {}
+}
+
 variable "ebs_device" {
   type        = string
   default     = ""

--- a/aws/asg-efs/README.md
+++ b/aws/asg-efs/README.md
@@ -28,6 +28,7 @@ an auto scaling group that uses the template.  An EFS file system is mounted.
  - `associate_public_ip_address` - true/false - Whether or not to associate public ip addresses with instances. Default: false
  - `additional_user_data` - command to append to the EC2 user\_data, default is ""
  - `tags` - A list of tag definitions to be applied to the asg. See example below.
+ - `lt_tags` - A map of tag definitions to be applied to the network interfaces and volumes created by the launch template. See example below.
 
 ## Outputs
 
@@ -58,5 +59,10 @@ module "asg" {
       propagate_at_launch = true
     },
   ]
+
+  lt_tags = {
+    tagname1 = "value1"
+    tagname2 = "value2"
+  }
 }
 ```

--- a/aws/asg-efs/main.tf
+++ b/aws/asg-efs/main.tf
@@ -42,6 +42,17 @@ resource "aws_launch_template" "asg_lt" {
   monitoring {
     enabled = true
   }
+
+  dynamic "tag_specifications" {
+    for_each = ["network-interface", "volume"]
+    iterator = resource
+
+    content {
+      resource_type = resource.value
+
+      tags = var.lt_tags
+    }
+  }
 }
 
 /*

--- a/aws/asg-efs/vars.tf
+++ b/aws/asg-efs/vars.tf
@@ -83,3 +83,9 @@ variable "tags" {
   description = "Additional tags to add to asg."
   default     = []
 }
+
+variable "lt_tags" {
+  type        = map(string)
+  description = "Map of tags to be added to network-interface and volume created by the launch template"
+  default     = {}
+}

--- a/aws/asg/README.md
+++ b/aws/asg/README.md
@@ -26,6 +26,8 @@ an auto scaling group that uses the template.
  - `associate_public_ip_address` - true/false - Whether or not to associate public ip addresses with instances. Default: false
  - `additional_user_data` - command to append to the EC2 user\_data, default is ""
  - `tags` - A list of tag definitions to be applied to the asg. See example below.
+ - `lt_tags` - A map of tag definitions to be applied to the network interfaces and volumes crea
+ted by the launch template. See example below.
 
 ## Outputs
 
@@ -54,5 +56,10 @@ module "asg" {
       propagate_at_launch = true
     },
   ]
+
+  lt_tags = {
+    tagname1 = "value1"
+    tagname2 = "value2"
+  }
 }
 ```

--- a/aws/asg/main.tf
+++ b/aws/asg/main.tf
@@ -40,6 +40,17 @@ resource "aws_launch_template" "asg_lt" {
   monitoring {
     enabled = true
   }
+
+  dynamic "tag_specifications" {
+    for_each = ["network-interface", "volume"]
+    iterator = resource
+
+    content {
+      resource_type = resource.value
+
+      tags = var.lt_tags
+    }
+  }
 }
 
 /*

--- a/aws/asg/vars.tf
+++ b/aws/asg/vars.tf
@@ -73,3 +73,9 @@ variable "tags" {
   description = "Additional tags to add to asg."
   default     = []
 }
+
++variable "lt_tags" {
+  type        = map(string)
+  description = "Map of tags to be added to network-interface and volume created by the launch template"
+  default     = {}
+}


### PR DESCRIPTION
Optionally adds the specified tags to the network interfaces and volumes created by the launch template.