### PR TITLE
Release 7.2.0 - allow backup module to use an external sns topic

### DIFF
--- a/aws/backup/rds/vars.tf
+++ b/aws/backup/rds/vars.tf
@@ -38,7 +38,7 @@ variable "notification_events" {
 }
 
 variable "sns_topic_arn" {
-  description = "The SNS topic to use for notifications. Leave blank to disable notifications."
+  description = "The SNS topic to use for notifications. Leave blank to create a topic named backup-vault-events."
   type        = string
   default     = ""
 }

--- a/aws/backup/rds/vars.tf
+++ b/aws/backup/rds/vars.tf
@@ -37,3 +37,8 @@ variable "notification_events" {
   default     = ["BACKUP_JOB_STARTED", "BACKUP_JOB_COMPLETED", "BACKUP_JOB_FAILED", "RESTORE_JOB_COMPLETED"]
 }
 
+variable "sns_topic_arn" {
+  description = "The SNS topic to use for notifications. Leave blank to disable notifications."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
### Added
- Added a new variable `sns_topic_arn` to the `aws/backup` module to opt out of creating a dedicated SNS topic. This solves a shortcoming in this module that prevents its safe use in multiple places in the same AWS account.