### PR TITLE
combine tags variables (for 8.0.0)

### DIFF
--- a/aws/asg-ebs/README.md
+++ b/aws/asg-ebs/README.md
@@ -36,8 +36,7 @@ an auto scaling group that uses the template.  An EBS file system is mounted.
  - `ebs_mkfs_extraopts` - Extra options to pass to the mkfs command. Default: ""
  - `ebs_fs_type` - Type of filesystem to create. Default: `ext4`
  - `ebs_mountopts` - Mount options to include in /etc/fstab, default is "defaults,noatime"
- - `tags` - A list of tag definitions to be applied to the asg. See example below.
- - `lt_tags` - A map of tag definitions to be applied to the network interfaces and volumes created by the launch template. See example below.
+ - `tags` - Map of tags to be added to all resources, including the network-interface and volume created by the launch template. The `propagate_at_launch` flag will be set true for all tags.
 
 ## Outputs
 
@@ -67,17 +66,8 @@ module "asg" {
   ebs_mkfs_label = "MyBigFS"
   ebs_mkfs_extraopts = "-m 2 -i 32768"
 
-  tags = [
-    {
-      key                 = "foo"
-      value               = "bar"
-      propagate_at_launch = true
-    },
-  ]
-
-  lt_tags = {
-    tagname1 = "value1"
-    tagname2 = "value2"
+  tags = {
+    foo = bar
   }
 }
 ```

--- a/aws/asg-ebs/main.tf
+++ b/aws/asg-ebs/main.tf
@@ -59,7 +59,7 @@ resource "aws_launch_template" "asg_lt" {
     content {
       resource_type = resource.value
 
-      tags = var.lt_tags
+      tags = var.tags
     }
   }
 }
@@ -104,10 +104,9 @@ resource "aws_autoscaling_group" "asg" {
     for_each = var.tags
 
     content {
-      key                 = tag.value.key
-      value               = tag.value.value
-      propagate_at_launch = tag.value.propagate_at_launch
+      key                 = tag.key
+      value               = tag.value
+      propagate_at_launch = true
     }
   }
 }
-

--- a/aws/asg-ebs/vars.tf
+++ b/aws/asg-ebs/vars.tf
@@ -78,14 +78,8 @@ variable "additional_user_data" {
 }
 
 variable "tags" {
-  type        = list(map(any))
-  description = "Additional tags to add to asg."
-  default     = []
-}
-
-variable "lt_tags" {
   type        = map(string)
-  description = "Map of tags to be added to network-interface and volume created by the launch template"
+  description = "Map of tags to be added to all resources, including the network-interface and volume created by the launch template"
   default     = {}
 }
 

--- a/aws/asg/README.md
+++ b/aws/asg/README.md
@@ -25,9 +25,7 @@ an auto scaling group that uses the template.
  - `additional_security_groups` - List of additional security groups (in addition to default vpc security group)
  - `associate_public_ip_address` - true/false - Whether or not to associate public ip addresses with instances. Default: false
  - `additional_user_data` - command to append to the EC2 user\_data, default is ""
- - `tags` - A list of tag definitions to be applied to the asg. See example below.
- - `lt_tags` - A map of tag definitions to be applied to the network interfaces and volumes crea
-ted by the launch template. See example below.
+ - `tags` - Map of tags to be added to all resources, including the network-interface and volume created by the launch template. The `propagate_at_launch` flag will be set true for all tags.
 
 ## Outputs
 
@@ -49,17 +47,8 @@ module "asg" {
   ami_id = "${module.ecs.ami_id}"
   additional_user_data = "yum install -y something-interesting"
 
-  tags = [
-    {
-      key                 = "foo"
-      value               = "bar"
-      propagate_at_launch = true
-    },
-  ]
-
-  lt_tags = {
-    tagname1 = "value1"
-    tagname2 = "value2"
+  tags = {
+    foo = bar
   }
 }
 ```

--- a/aws/asg/main.tf
+++ b/aws/asg/main.tf
@@ -48,7 +48,7 @@ resource "aws_launch_template" "asg_lt" {
     content {
       resource_type = resource.value
 
-      tags = var.lt_tags
+      tags = var.tags
     }
   }
 }
@@ -93,10 +93,9 @@ resource "aws_autoscaling_group" "asg" {
     for_each = var.tags
 
     content {
-      key                 = tag.value.key
-      value               = tag.value.value
-      propagate_at_launch = tag.value.propagate_at_launch
+      key                 = tag.key
+      value               = tag.value
+      propagate_at_launch = true
     }
   }
 }
-

--- a/aws/asg/vars.tf
+++ b/aws/asg/vars.tf
@@ -69,13 +69,7 @@ variable "additional_user_data" {
 }
 
 variable "tags" {
-  type        = list(map(any))
-  description = "Additional tags to add to asg."
-  default     = []
-}
-
-+variable "lt_tags" {
   type        = map(string)
-  description = "Map of tags to be added to network-interface and volume created by the launch template"
+  description = "Map of tags to be added to all resources, including the network-interface and volume created by the launch template"
   default     = {}
 }


### PR DESCRIPTION
### Changed (breaking)
- Changed `tags` variable in aws/asg and aws/asg-ebs from a list of maps to a map and set `propagate_at_launch` true for every tag created by the map.

### Removed
- Removed `lt_tags` from aws/asg and aws/asg-ebs modules and use the changed `tags` variable in its place.