### PR TITLE
Release 8.0.1 - fix RDS multi-AZ availability zone input

### DIFF
--- a/aws/rds/mariadb/main.tf
+++ b/aws/rds/mariadb/main.tf
@@ -12,7 +12,7 @@ resource "aws_db_instance" "db_instance" {
   storage_type            = var.storage_type
   storage_encrypted       = var.storage_encrypted
   kms_key_id              = var.kms_key_id
-  availability_zone       = var.multi_az == "true" ? "" : var.availability_zone
+  availability_zone       = var.multi_az ? "" : var.availability_zone
   backup_retention_period = var.backup_retention_period
   multi_az                = var.multi_az
   publicly_accessible     = var.publicly_accessible
@@ -27,4 +27,3 @@ resource "aws_db_instance" "db_instance" {
     app_env  = var.app_env
   }, var.tags)
 }
-

--- a/aws/rds/mariadb/outputs.tf
+++ b/aws/rds/mariadb/outputs.tf
@@ -18,3 +18,6 @@ output "endpoint" {
   value = aws_db_instance.db_instance.endpoint
 }
 
+output "availability_zone" {
+  value = aws_db_instance.db_instance.availability_zone
+}

--- a/aws/rds/mariadb/vars.tf
+++ b/aws/rds/mariadb/vars.tf
@@ -21,18 +21,8 @@ variable "db_root_pass" {
   type = string
 }
 
-variable "deletion_protection" {
-  type    = bool
-  default = false
-}
-
 variable "subnet_group_name" {
   type = string
-}
-
-variable "availability_zone" {
-  type    = string
-  default = ""
 }
 
 variable "security_groups" {
@@ -42,9 +32,20 @@ variable "security_groups" {
 /*
  * Optional variables
  */
+
+variable "availability_zone" {
+  type    = string
+  default = ""
+}
+
 variable "copy_tags_to_snapshot" {
   type    = bool
   default = true
+}
+
+variable "deletion_protection" {
+  type    = bool
+  default = false
 }
 
 variable "engine" {


### PR DESCRIPTION
### Fixed
- Use a non-strict type comparison on `multi_az` when assigning the `availability_zone` input to the resource.

### Added
- Add `availability_zone` as an output of the aws/rds/mariadb module
