### PR TITLE
Release 8.2.1 - fix aws/rds/mariadb module

### DIFF
--- a/aws/rds/mariadb/main.tf
+++ b/aws/rds/mariadb/main.tf
@@ -4,10 +4,10 @@ resource "aws_db_instance" "db_instance" {
   allocated_storage       = var.allocated_storage
   copy_tags_to_snapshot   = var.copy_tags_to_snapshot
   instance_class          = var.instance_class
-  db_name                 = var.replicate_source_db == "" ? var.db_name : ""
+  db_name                 = var.replicate_source_db == null ? var.db_name : null
   identifier              = "${var.app_name}-${var.app_env}"
-  username                = var.replicate_source_db == "" ? var.db_root_user : ""
-  password                = var.replicate_source_db == "" ? var.db_root_pass : ""
+  username                = var.replicate_source_db == null ? var.db_root_user : null
+  password                = var.replicate_source_db == null ? var.db_root_pass : null
   db_subnet_group_name    = var.subnet_group_name
   storage_type            = var.storage_type
   storage_encrypted       = var.storage_encrypted

--- a/aws/rds/mariadb/vars.tf
+++ b/aws/rds/mariadb/vars.tf
@@ -117,11 +117,11 @@ variable "tags" {
 variable "replicate_source_db" {
   type        = string
   description = "To create a replica DB, specify the source database"
-  default     = ""
+  default     = null
 }
 
 variable "replica_mode" {
   type        = string
   description = "Specifies whether the replica is in either \"mounted\" or \"open-read-only\" mode. This attribute is only supported by Oracle instances."
-  default     = ""
+  default     = null
 }


### PR DESCRIPTION
### Fixed
- Fix a bug introduced in v8.2.0 indicated by error messages:
  - "username": conflicts with replicate_source_db
  - expected replica_mode to be one of [open-read-only mounted]