### PR TITLE
Add 'cpu_credits' to 'aws_instance'

### DIFF
--- a/aws/asg-ebs/README.md
+++ b/aws/asg-ebs/README.md
@@ -12,7 +12,7 @@ an auto scaling group that uses the template.  An EBS file system is mounted.
  - `app_name` - Name of application, ex: Doorman, IdP, etc.
  - `app_env` - Name of environment, ex: prod, test, etc.
  - `ami_id` - ID for AMI to be used.
- - `aws_instance` - A map containing keys for `instance_type`, `volume_size`, `instance_count`
+ - `aws_instance` - A map containing keys for `instance_type`, `volume_size`, `instance_count`, `cpu_credits`
  - `aws_region` - Default AWS region
  - `aws_access_key` - Access key to allow access via the AWS CLI
  - `aws_secret_key` - Secret access key to allow access via the AWS CLI

--- a/aws/asg-ebs/README.md
+++ b/aws/asg-ebs/README.md
@@ -12,7 +12,7 @@ an auto scaling group that uses the template.  An EBS file system is mounted.
  - `app_name` - Name of application, ex: Doorman, IdP, etc.
  - `app_env` - Name of environment, ex: prod, test, etc.
  - `ami_id` - ID for AMI to be used.
- - `aws_instance` - A map containing keys for `instance_type`, `volume_size`, `instance_count`, `cpu_credits`
+ - `aws_instance` - A map containing keys for `instance_type`, `volume_size`, `instance_count`
  - `aws_region` - Default AWS region
  - `aws_access_key` - Access key to allow access via the AWS CLI
  - `aws_secret_key` - Secret access key to allow access via the AWS CLI
@@ -37,6 +37,7 @@ an auto scaling group that uses the template.  An EBS file system is mounted.
  - `ebs_fs_type` - Type of filesystem to create. Default: `ext4`
  - `ebs_mountopts` - Mount options to include in /etc/fstab, default is "defaults,noatime"
  - `tags` - Map of tags to be added to all resources, including the network-interface and volume created by the launch template. The `propagate_at_launch` flag will be set true for all tags.
+ - `cpu_credits` - Value for the `credit_specification` if you want to override the AWS default for `aws_launch_template`.
 
 ## Outputs
 

--- a/aws/asg-ebs/main.tf
+++ b/aws/asg-ebs/main.tf
@@ -40,7 +40,7 @@ resource "aws_launch_template" "asg_lt" {
   }
 
   credit_specification {
-    cpu_credits = var.aws_instance["cpu_credits"]
+    cpu_credits = var.cpu_credits
   }
 
   network_interfaces {

--- a/aws/asg-ebs/main.tf
+++ b/aws/asg-ebs/main.tf
@@ -39,6 +39,10 @@ resource "aws_launch_template" "asg_lt" {
     }
   }
 
+  credit_specification {
+    cpu_credits = var.aws_instance["cpu_credits"]
+  }
+
   network_interfaces {
     associate_public_ip_address = var.associate_public_ip_address
     security_groups             = concat([var.default_sg_id], var.additional_security_groups)

--- a/aws/asg-ebs/vars.tf
+++ b/aws/asg-ebs/vars.tf
@@ -33,6 +33,7 @@ variable "aws_instance" {
     instance_type  = "t2.micro"
     volume_size    = "8"
     instance_count = "3"
+    cpu_credits    = "standard"
   }
 }
 

--- a/aws/asg-ebs/vars.tf
+++ b/aws/asg-ebs/vars.tf
@@ -33,8 +33,13 @@ variable "aws_instance" {
     instance_type  = "t2.micro"
     volume_size    = "8"
     instance_count = "3"
-    cpu_credits    = "standard"
   }
+}
+
+variable "cpu_credits" {
+  description = "One of 'standard', 'unlimited'"
+  type        = string
+  default     = null
 }
 
 variable "root_device_name" {

--- a/aws/asg/README.md
+++ b/aws/asg/README.md
@@ -12,7 +12,7 @@ an auto scaling group that uses the template.
  - `app_name` - Name of application, ex: Doorman, IdP, etc.
  - `app_env` - Name of environment, ex: prod, test, etc.
  - `ami_id` - ID for AMI to be used.
- - `aws_instance` - A map containing keys for `instance_type`, `volume_size`, `instance_count`
+ - `aws_instance` - A map containing keys for `instance_type`, `volume_size`, `instance_count`, `cpu_credits`
  - `private_subnet_ids` - A list of private subnet ids to identify VPC subnets for placement
  - `default_sg_id` - VPC default security group ID to add instances to
  - `ecs_instance_profile_id` - IAM profile ID for ecsInstanceProfile

--- a/aws/asg/README.md
+++ b/aws/asg/README.md
@@ -12,7 +12,7 @@ an auto scaling group that uses the template.
  - `app_name` - Name of application, ex: Doorman, IdP, etc.
  - `app_env` - Name of environment, ex: prod, test, etc.
  - `ami_id` - ID for AMI to be used.
- - `aws_instance` - A map containing keys for `instance_type`, `volume_size`, `instance_count`, `cpu_credits`
+ - `aws_instance` - A map containing keys for `instance_type`, `volume_size`, `instance_count`
  - `private_subnet_ids` - A list of private subnet ids to identify VPC subnets for placement
  - `default_sg_id` - VPC default security group ID to add instances to
  - `ecs_instance_profile_id` - IAM profile ID for ecsInstanceProfile
@@ -26,6 +26,7 @@ an auto scaling group that uses the template.
  - `associate_public_ip_address` - true/false - Whether or not to associate public ip addresses with instances. Default: false
  - `additional_user_data` - command to append to the EC2 user\_data, default is ""
  - `tags` - Map of tags to be added to all resources, including the network-interface and volume created by the launch template. The `propagate_at_launch` flag will be set true for all tags.
+ - `cpu_credits` - Value for the `credit_specification` if you want to override the AWS default for `aws_launch_template`.
 
 ## Outputs
 

--- a/aws/asg/main.tf
+++ b/aws/asg/main.tf
@@ -28,6 +28,10 @@ resource "aws_launch_template" "asg_lt" {
     }
   }
 
+  credit_specification {
+    cpu_credits = var.aws_instance["cpu_credits"]
+  }
+
   network_interfaces {
     associate_public_ip_address = var.associate_public_ip_address
     security_groups             = concat([var.default_sg_id], var.additional_security_groups)

--- a/aws/asg/main.tf
+++ b/aws/asg/main.tf
@@ -29,7 +29,7 @@ resource "aws_launch_template" "asg_lt" {
   }
 
   credit_specification {
-    cpu_credits = var.aws_instance["cpu_credits"]
+    cpu_credits = var.cpu_credits
   }
 
   network_interfaces {

--- a/aws/asg/vars.tf
+++ b/aws/asg/vars.tf
@@ -27,6 +27,7 @@ variable "aws_instance" {
     instance_type  = "t2.micro"
     volume_size    = "8"
     instance_count = "3"
+    cpu_credits    = "standard"
   }
 }
 

--- a/aws/asg/vars.tf
+++ b/aws/asg/vars.tf
@@ -27,8 +27,13 @@ variable "aws_instance" {
     instance_type  = "t2.micro"
     volume_size    = "8"
     instance_count = "3"
-    cpu_credits    = "standard"
   }
+}
+
+variable "cpu_credits" {
+  description = "One of 'standard', 'unlimited'"
+  type        = string
+  default     = null
 }
 
 variable "root_device_name" {

--- a/test/asg.tf
+++ b/test/asg.tf
@@ -1,0 +1,29 @@
+module "asg-test" {
+  source                  = "../aws/asg"
+  app_name                = "test_name1"
+  app_env                 = "test_env1"
+  ami_id                  = "ami-1234567890"
+  aws_instance            = {instance_type="t3.nano", volume_size="8", instance_count="1"}
+  private_subnet_ids      = ["1234", "5678"]
+  default_sg_id           = "sg-asdf"
+  ecs_instance_profile_id = "asdf"
+  ecs_cluster_name        = "mycluster1"
+}
+
+module "asg-ebs-test" {
+  source              = "../aws/asg-ebs"
+  app_name                = "test_name2"
+  app_env                 = "test_env2"
+  ami_id                  = "ami-1234567890"
+  aws_instance            = {instance_type="t3.nano", volume_size="8", instance_count="1"}
+  aws_region              = "us-west-2"
+  aws_access_key          = "ALKJDFIEO"
+  aws_secret_key          = "asdfljkasdflkjasdflkjasdflkjasdflkjasdf"
+  private_subnet_ids      = ["1234", "5678"]
+  default_sg_id           = "sg-asdf"
+  ecs_instance_profile_id = "asdf"
+  ecs_cluster_name        = "mycluster1"
+  ebs_device              = "/dev/sdh"
+  ebs_mount_point         = "/foo/bah"
+  ebs_vol_id              = "vol-123456789"
+}

--- a/test/asg.tf
+++ b/test/asg.tf
@@ -3,7 +3,7 @@ module "asg-test" {
   app_name                = "test_name1"
   app_env                 = "test_env1"
   ami_id                  = "ami-1234567890"
-  aws_instance            = {instance_type="t3.nano", volume_size="8", instance_count="1"}
+  aws_instance            = { instance_type = "t3.nano", volume_size = "8", instance_count = "1" }
   private_subnet_ids      = ["1234", "5678"]
   default_sg_id           = "sg-asdf"
   ecs_instance_profile_id = "asdf"
@@ -11,14 +11,14 @@ module "asg-test" {
 }
 
 module "asg-ebs-test" {
-  source              = "../aws/asg-ebs"
+  source                  = "../aws/asg-ebs"
   app_name                = "test_name2"
   app_env                 = "test_env2"
   ami_id                  = "ami-1234567890"
-  aws_instance            = {instance_type="t3.nano", volume_size="8", instance_count="1"}
+  aws_instance            = { instance_type = "t3.nano", volume_size = "8", instance_count = "1" }
   aws_region              = "us-west-2"
-  aws_access_key          = "ALKJDFIEO"
-  aws_secret_key          = "asdfljkasdflkjasdflkjasdflkjasdflkjasdf"
+  aws_access_key          = "AKIA1234567890123456"
+  aws_secret_key          = "1234567890123456789012345678901234567890"
   private_subnet_ids      = ["1234", "5678"]
   default_sg_id           = "sg-asdf"
   ecs_instance_profile_id = "asdf"


### PR DESCRIPTION
The AWS default for cpu_credits is "standard" for t2 EC2 instances and "unlimited" for t3 EC2 instances.  Adding cpu_credits to aws_instance allows the user to choose a non-default value.