### PR TITLE
Fix cpu_credit backwards compatibility

### DIFF
--- a/aws/asg-ebs/main.tf
+++ b/aws/asg-ebs/main.tf
@@ -17,6 +17,7 @@ locals {
     ebs_fs_type          = var.ebs_fs_type
     ebs_mountopts        = var.ebs_mountopts
   })
+  credits = [var.cpu_credits]
 }
 
 /*
@@ -39,8 +40,12 @@ resource "aws_launch_template" "asg_lt" {
     }
   }
 
-  credit_specification {
-    cpu_credits = var.cpu_credits
+  dynamic "credit_specification" {
+    iterator = ii
+    for_each = local.credits
+    content {
+      cpu_credits = ii.value
+    }
   }
 
   network_interfaces {

--- a/aws/asg-ebs/main.tf
+++ b/aws/asg-ebs/main.tf
@@ -17,7 +17,7 @@ locals {
     ebs_fs_type          = var.ebs_fs_type
     ebs_mountopts        = var.ebs_mountopts
   })
-  credits = [var.cpu_credits]
+  credits = var.cpu_credits == "" ? [] : [var.cpu_credits]
 }
 
 /*

--- a/aws/asg-ebs/vars.tf
+++ b/aws/asg-ebs/vars.tf
@@ -39,7 +39,7 @@ variable "aws_instance" {
 variable "cpu_credits" {
   description = "One of 'standard', 'unlimited'"
   type        = string
-  default     = null
+  default     = ""
 }
 
 variable "root_device_name" {

--- a/aws/asg/main.tf
+++ b/aws/asg/main.tf
@@ -6,7 +6,7 @@ locals {
     ecs_cluster_name     = var.ecs_cluster_name
     additional_user_data = var.additional_user_data
   })
-  credits = [var.cpu_credits]
+  credits = var.cpu_credits == "" ? [] : [var.cpu_credits]
 }
 
 /*

--- a/aws/asg/main.tf
+++ b/aws/asg/main.tf
@@ -6,6 +6,7 @@ locals {
     ecs_cluster_name     = var.ecs_cluster_name
     additional_user_data = var.additional_user_data
   })
+  credits = [var.cpu_credits]
 }
 
 /*
@@ -28,8 +29,12 @@ resource "aws_launch_template" "asg_lt" {
     }
   }
 
-  credit_specification {
-    cpu_credits = var.cpu_credits
+  dynamic "credit_specification" {
+    iterator = ii
+    for_each = local.credits
+    content {
+      cpu_credits = ii.value
+    }
   }
 
   network_interfaces {

--- a/aws/asg/vars.tf
+++ b/aws/asg/vars.tf
@@ -33,7 +33,7 @@ variable "aws_instance" {
 variable "cpu_credits" {
   description = "One of 'standard', 'unlimited'"
   type        = string
-  default     = null
+  default     = ""
 }
 
 variable "root_device_name" {


### PR DESCRIPTION
Use a `dynamic credit_specification` and an empty string as the default value for `cpu_credits`.  Tested and worked for two cases:

- EC2 T2 without specifying `cpu_credits` (what we have now)
- EC2 T3 with `cpu_credits = "standard"`