### PR TITLE
Enable customizing VPC's CIDR blocks

### DIFF
--- a/aws/vpc/README.md
+++ b/aws/vpc/README.md
@@ -25,7 +25,7 @@ be useful.
 
  - `vpc_default_sg_id` - The VPC default security group ID
  - `public_subnet_ids` - A list of the public subnet IDs
- - `public_subnet_cidr_blocks` - A list of public subnet CIDR blocks, ex: `["10.0.10.0/24","10.0.12.0/24"]`
+ - `public_subnet_cidr_blocks` - A list of public subnet CIDR blocks, ex: `["10.0.10.0/24","10.0.20.0/24"]`
  - `private_subnet_ids` - A list of the private subnet IDs
  - `private_subnet_cidr_blocks` - A list of private subnet CIDR blocks, ex: `["10.0.11.0/24","10.0.22.0/24"]`
  - `db_subnet_group_name` - The name of the DB subnet group

--- a/aws/vpc/README.md
+++ b/aws/vpc/README.md
@@ -20,6 +20,9 @@ be useful.
 
  - `enable_dns_hostnames` - default `false`
  - `create_nat_gateway` - default `true`
+ - `private_subnet_cidr_blocks`
+ - `public_subnet_cidr_blocks`
+ - `vpc_cidr_block`
 
 ## Outputs
 

--- a/aws/vpc/main.tf
+++ b/aws/vpc/main.tf
@@ -27,7 +27,7 @@ resource "aws_subnet" "public_subnet" {
   count             = length(var.aws_zones)
   vpc_id            = aws_vpc.vpc.id
   availability_zone = element(var.aws_zones, count.index)
-  cidr_block        = "10.0.${(count.index + 1) * 10}.0/24"
+  cidr_block        = element(var.public_subnet_cidr_blocks, count.index)
 
   tags = {
     Name     = "public-${element(var.aws_zones, count.index)}"

--- a/aws/vpc/main.tf
+++ b/aws/vpc/main.tf
@@ -2,7 +2,7 @@
  * Create VPC using app name and env to name it
  */
 resource "aws_vpc" "vpc" {
-  cidr_block           = "10.0.0.0/16"
+  cidr_block           = var.vpc_cidr_block
   enable_dns_hostnames = var.enable_dns_hostnames
 
   tags = {

--- a/aws/vpc/main.tf
+++ b/aws/vpc/main.tf
@@ -40,7 +40,7 @@ resource "aws_subnet" "private_subnet" {
   count             = length(var.aws_zones)
   vpc_id            = aws_vpc.vpc.id
   availability_zone = element(var.aws_zones, count.index)
-  cidr_block        = "10.0.${(count.index + 1) * 11}.0/24"
+  cidr_block        = element(var.private_subnet_cidr_blocks, count.index)
 
   tags = {
     Name     = "private-${element(var.aws_zones, count.index)}"

--- a/aws/vpc/vars.tf
+++ b/aws/vpc/vars.tf
@@ -32,6 +32,12 @@ variable "create_nat_gateway" {
   default     = true
 }
 
+variable "public_subnet_cidr_blocks" {
+  description = "The CIDR blocks for the public subnets (one per AZ, in order). There must be at least as many public CIDRs as AZs, and they must not overlap the private CIDRs."
+  type        = list(string)
+  default     = ["10.0.10.0/24", "10.0.20.0/24", "10.0.30.0/24", "10.0.40.0/24"]
+}
+
 variable "vpc_cidr_block" {
   description = "The block of IP addresses (as a CIDR) the VPC should use"
   type        = string

--- a/aws/vpc/vars.tf
+++ b/aws/vpc/vars.tf
@@ -32,6 +32,12 @@ variable "create_nat_gateway" {
   default     = true
 }
 
+variable "private_subnet_cidr_blocks" {
+  description = "The CIDR blocks for the private subnets (one per AZ, in order). There must be at least as many private CIDRs as AZs, and they must not overlap the public CIDRs."
+  type        = list(string)
+  default     = ["10.0.11.0/24", "10.0.22.0/24", "10.0.33.0/24", "10.0.44.0/24"]
+}
+
 variable "public_subnet_cidr_blocks" {
   description = "The CIDR blocks for the public subnets (one per AZ, in order). There must be at least as many public CIDRs as AZs, and they must not overlap the private CIDRs."
   type        = list(string)

--- a/aws/vpc/vars.tf
+++ b/aws/vpc/vars.tf
@@ -31,3 +31,9 @@ variable "create_nat_gateway" {
   type        = bool
   default     = true
 }
+
+variable "vpc_cidr_block" {
+  description = "The block of IP addresses (as a CIDR) the VPC should use"
+  type        = string
+  default     = "10.0.0.0/16"
+}


### PR DESCRIPTION
[IDP-708](https://itse.youtrack.cloud/issue/IDP-708) Enable using a smaller VPC subnet range for the IDP

---

### Added
- Enable using a custom CIDR block for the VPC (optional)
- Make the public subnets' CIDR blocks configurable (optionally)
- Make the private subnets' CIDR blocks configurable (optionally)
- Add new variables to vpc's README's list of optional inputs

### Fixed
- Fix typo in vpc README example

---

**Note:**
I set the defaults to match the calculated values we have been using, so that this should be a non-breaking change (unless someone is using more than 4 availability zones, which we aren't, as far as I am aware).