### PR TITLE
Release 8.6.1 - Update the Launch Template version number each time

### DIFF
--- a/aws/asg/main.tf
+++ b/aws/asg/main.tf
@@ -13,13 +13,13 @@ locals {
  * Create Launch Template
  */
 resource "aws_launch_template" "asg_lt" {
-  default_version = 1
-  ebs_optimized   = false
-  name            = "lt-${var.app_name}-${var.app_env}"
-  image_id        = var.ami_id
-  instance_type   = var.aws_instance["instance_type"]
-  key_name        = var.key_name
-  user_data       = base64encode(local.user_data)
+  ebs_optimized          = false
+  name                   = "lt-${var.app_name}-${var.app_env}"
+  image_id               = var.ami_id
+  instance_type          = var.aws_instance["instance_type"]
+  key_name               = var.key_name
+  update_default_version = true
+  user_data              = base64encode(local.user_data)
 
   block_device_mappings {
     device_name = var.root_device_name


### PR DESCRIPTION
### Fixed
- Rather than setting the default_version to 1, use the latest version ([documentation](https://registry.terraform.io/providers/hashicorp/aws/4.67.0/docs/resources/launch_template#update_default_version))