### PR TITLE
Release 8.10.0 - add IPv6 support to vpc and cloudflare-sg

### DIFF
--- a/aws/cloudflare-sg/main.tf
+++ b/aws/cloudflare-sg/main.tf
@@ -15,14 +15,5 @@ resource "aws_security_group_rule" "cloudflare_ipv4" {
   protocol          = "tcp"
   security_group_id = aws_security_group.cloudflare_https.id
   cidr_blocks       = module.cf_ips.ipv4_cidrs
+  ipv6_cidr_blocks  = module.cf_ips.ipv6_cidrs
 }
-
-// IPv6 not supported by security groups yet
-/*resource "aws_security_group_rule" "cloudflare_ipv6" {
-  type = "ingress"
-  from_port = 443
-  to_port = 443
-  protocol = "tcp"
-  security_group_id = "${aws_security_group.cloudflare_https.id}"
-  cidr_blocks = ["${module.cf_ips.ipv6_cidrs}"]
-}*/

--- a/aws/vpc/README.md
+++ b/aws/vpc/README.md
@@ -9,6 +9,7 @@ be useful.
 - Provision a Internet Gateway and configure public subnets to route through it
 - Provision a NAT Gateway (or use an existing Transit Gateway) and configure private subnets to route through it
 - Create a DB subnet group including all private subnets
+- Optionally allocate IPv6 CIDR blocks, egress-only internet gateway, and default IPv6 routes
 
 ## Required Inputs
 
@@ -27,6 +28,7 @@ be useful.
 - `transit_gateway_id` - required if `use_transit_gateway` is true
 - `transit_gateway_default_route_table_association` - default `true`
 - `transit_gateway_default_route_table_propagation` - default `true`
+- `ipv6_enable` - default `false` 
 
 ## Outputs
 

--- a/aws/vpc/README.md
+++ b/aws/vpc/README.md
@@ -28,7 +28,7 @@ be useful.
 - `transit_gateway_id` - required if `use_transit_gateway` is true
 - `transit_gateway_default_route_table_association` - default `true`
 - `transit_gateway_default_route_table_propagation` - default `true`
-- `ipv6_enable` - default `false` 
+- `enable_ipv6` - default `false` 
 
 ## Outputs
 

--- a/aws/vpc/README.md
+++ b/aws/vpc/README.md
@@ -13,7 +13,7 @@ be useful.
 
 ## Required Inputs
 
-- `app_name` - Name of application, ex: Doorman, IdP, etc.
+- `app_name` - Name of application, ex: Cover, IdP, etc.
 - `app_env` - Name of environment, ex: prod, test, etc.
 
 ## Optional Inputs

--- a/aws/vpc/README.md
+++ b/aws/vpc/README.md
@@ -4,46 +4,48 @@ be useful.
 
 ## What this does
 
- - Create VPC named after `app_name` and `app_env`
- - Create public and private subnets for each `aws_zones` specified
- - Provision a Internet Gateway and configure public subnets to route through it
- - Provision a NAT Gateway (or use an existing Transit Gateway) and configure private subnets to route through it
- - Create a DB subnet group including all private subnets
+- Create VPC named after `app_name` and `app_env`
+- Create public and private subnets for each `aws_zones` specified
+- Provision a Internet Gateway and configure public subnets to route through it
+- Provision a NAT Gateway (or use an existing Transit Gateway) and configure private subnets to route through it
+- Create a DB subnet group including all private subnets
 
 ## Required Inputs
 
- - `app_name` - Name of application, ex: Doorman, IdP, etc.
- - `app_env` - Name of environment, ex: prod, test, etc.
- - `aws_zones` - A list of zones to create subnets in, ex: `["us-east-1c", "us-east-1d", "us-east-1e"]`
+- `app_name` - Name of application, ex: Doorman, IdP, etc.
+- `app_env` - Name of environment, ex: prod, test, etc.
 
 ## Optional Inputs
 
- - `enable_dns_hostnames` - default `false`
- - `create_nat_gateway` - default `true`
- - `private_subnet_cidr_blocks`
- - `public_subnet_cidr_blocks`
- - `vpc_cidr_block`
- - `use_transit_gateway` - default `false`
- - `transit_gateway_id` - required if `use_transit_gateway` is true
- - `transit_gateway_default_route_table_association` - default `true`
- - `transit_gateway_default_route_table_propagation` - default `true`
+- `aws_zones` - A list of zones to create subnets (max 8) - default: `["us-east-1c", "us-east-1d", "us-east-1e"]`
+- `enable_dns_hostnames` - default `false`
+- `create_nat_gateway` - default `true`
+- `private_subnet_cidr_blocks` - default: `["10.0.11.0/24", "10.0.22.0/24", "10.0.33.0/24", "10.0.44.0/24"]`
+- `public_subnet_cidr_blocks` - default: `["10.0.10.0/24", "10.0.20.0/24", "10.0.30.0/24", "10.0.40.0/24"]`
+- `vpc_cidr_block` - default: `"10.0.0.0/16"`
+- `use_transit_gateway` - default `false`
+- `transit_gateway_id` - required if `use_transit_gateway` is true
+- `transit_gateway_default_route_table_association` - default `true`
+- `transit_gateway_default_route_table_propagation` - default `true`
 
 ## Outputs
 
- - `vpc_default_sg_id` - The VPC default security group ID
- - `public_subnet_ids` - A list of the public subnet IDs
- - `public_subnet_cidr_blocks` - A list of public subnet CIDR blocks, ex: `["10.0.10.0/24","10.0.20.0/24"]`
- - `private_subnet_ids` - A list of the private subnet IDs
- - `private_subnet_cidr_blocks` - A list of private subnet CIDR blocks, ex: `["10.0.11.0/24","10.0.22.0/24"]`
- - `db_subnet_group_name` - The name of the DB subnet group
+- `vpc_default_sg_id` - The VPC default security group ID
+- `public_subnet_ids` - A list of the public subnet IDs
+- `public_subnet_cidr_blocks` - A list of public subnet CIDR blocks, ex: `["10.0.10.0/24","10.0.20.0/24"]`
+- `private_subnet_ids` - A list of the private subnet IDs
+- `private_subnet_cidr_blocks` - A list of private subnet CIDR blocks, ex: `["10.0.11.0/24","10.0.22.0/24"]`
+- `db_subnet_group_name` - The name of the DB subnet group
+- `ipv6_association_id` - The association ID for the IPv6 CIDR block.
+- `ipv6_cidr_block` - The IPv6 CIDR block assigned to the VPC.
 
 ## Example Usage
 
 ```hcl
 module "vpc" {
   source = "github.com/silinternational/terraform-modules//aws/vpc"
-  app_name = "${var.app_name}"
-  app_env = "${var.app_env}"
-  aws_zones = "${var.aws_zones}"
+  app_name = var.app_name
+  app_env = var.app_env
+  aws_zones = var.aws_zones
 }
 ```

--- a/aws/vpc/main.tf
+++ b/aws/vpc/main.tf
@@ -2,8 +2,9 @@
  * Create VPC using app name and env to name it
  */
 resource "aws_vpc" "vpc" {
-  cidr_block           = var.vpc_cidr_block
-  enable_dns_hostnames = var.enable_dns_hostnames
+  cidr_block                       = var.vpc_cidr_block
+  enable_dns_hostnames             = var.enable_dns_hostnames
+  assign_generated_ipv6_cidr_block = var.ipv6_enable
 
   tags = {
     Name     = "vpc-${var.app_name}-${var.app_env}"
@@ -23,11 +24,19 @@ data "aws_security_group" "vpc_default_sg" {
 /*
  * Create public and private subnets for each availability zone
  */
+
+locals {
+  ipv6_cidr_block = aws_vpc.vpc.ipv6_cidr_block
+  public_subnets  = var.ipv6_enable ? cidrsubnets(cidrsubnet(local.ipv6_cidr_block, 4, 0), 4, 4, 4, 4, 4, 4, 4, 4) : []
+  private_subnets = var.ipv6_enable ? cidrsubnets(cidrsubnet(local.ipv6_cidr_block, 4, 1), 4, 4, 4, 4, 4, 4, 4, 4) : []
+}
+
 resource "aws_subnet" "public_subnet" {
   count             = length(var.aws_zones)
   vpc_id            = aws_vpc.vpc.id
   availability_zone = element(var.aws_zones, count.index)
   cidr_block        = element(var.public_subnet_cidr_blocks, count.index)
+  ipv6_cidr_block   = var.ipv6_enable ? element(local.public_subnets, count.index) : null
 
   tags = {
     Name     = "public-${element(var.aws_zones, count.index)}"
@@ -41,6 +50,7 @@ resource "aws_subnet" "private_subnet" {
   vpc_id            = aws_vpc.vpc.id
   availability_zone = element(var.aws_zones, count.index)
   cidr_block        = element(var.private_subnet_cidr_blocks, count.index)
+  ipv6_cidr_block   = var.ipv6_enable ? element(local.private_subnets, count.index) : null
 
   tags = {
     Name     = "private-${element(var.aws_zones, count.index)}"
@@ -171,6 +181,14 @@ resource "aws_route" "igw_route" {
   route_table_id         = aws_route_table.igw_route_table.id
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = aws_internet_gateway.internet_gateway.id
+}
+
+resource "aws_route" "public_ipv6" {
+  count = var.ipv6_enable ? 1 : 0
+
+  route_table_id              = aws_route_table.igw_route_table.id
+  destination_ipv6_cidr_block = "::/0"
+  gateway_id                  = aws_internet_gateway.internet_gateway.id
 }
 
 resource "aws_route_table_association" "public_route" {

--- a/aws/vpc/outputs.tf
+++ b/aws/vpc/outputs.tf
@@ -1,6 +1,13 @@
-// Default Security Group ID
 output "id" {
   value = aws_vpc.vpc.id
+}
+
+output "ipv6_association_id" {
+  value = aws_vpc.vpc.ipv6_association_id
+}
+
+output "ipv6_cidr_block" {
+  value = aws_vpc.vpc.ipv6_cidr_block
 }
 
 output "vpc_default_sg_id" {
@@ -34,4 +41,3 @@ output "aws_zones" {
 output "nat_gateway_ip" {
   value = one(aws_nat_gateway.nat_gateway[*].public_ip)
 }
-

--- a/aws/vpc/vars.tf
+++ b/aws/vpc/vars.tf
@@ -75,7 +75,7 @@ variable "vpc_cidr_block" {
   default     = "10.0.0.0/16"
 }
 
-variable "ipv6_enable" {
+variable "enable_ipv6" {
   description = "Add an IPv6 CIDR block to the VPC and IPv6 CIDR blocks to the public and private subnets"
   type        = bool
   default     = false

--- a/aws/vpc/vars.tf
+++ b/aws/vpc/vars.tf
@@ -12,7 +12,8 @@ variable "app_env" {
 }
 
 variable "aws_zones" {
-  type = list(string)
+  description = "A list of zones to create subnets (max 8)"
+  type        = list(string)
 
   default = [
     "us-east-1c",
@@ -72,4 +73,10 @@ variable "vpc_cidr_block" {
   description = "The block of IP addresses (as a CIDR) the VPC should use"
   type        = string
   default     = "10.0.0.0/16"
+}
+
+variable "ipv6_enable" {
+  description = "Add an IPv6 CIDR block to the VPC and IPv6 CIDR blocks to the public and private subnets"
+  type        = bool
+  default     = false
 }

--- a/test/vpc.tf
+++ b/test/vpc.tf
@@ -1,4 +1,8 @@
-module "vpc" {
+module "vpc_minimal" {
+  source = "../aws/vpc"
+}
+
+module "vpc_all_inputs" {
   source = "../aws/vpc"
 
   app_name                                        = ""
@@ -13,4 +17,5 @@ module "vpc" {
   transit_gateway_default_route_table_association = false
   transit_gateway_default_route_table_propagation = false
   vpc_cidr_block                                  = ""
+  ipv6_enable                                     = true
 }

--- a/test/vpc.tf
+++ b/test/vpc.tf
@@ -17,5 +17,5 @@ module "vpc_all_inputs" {
   transit_gateway_default_route_table_association = false
   transit_gateway_default_route_table_propagation = false
   vpc_cidr_block                                  = ""
-  ipv6_enable                                     = true
+  enable_ipv6                                     = true
 }


### PR DESCRIPTION
### Added
- Added new outputs to `vpc` module: `ipv6_association_id`, `ipv6_cidr_block`
- Added new input to `vpc` module: `ipv6_enable`, which controls the following:
  - Optionally assign IPv6 CIDR blocks to VPC and subnets
  - Optionally add an IPv6 route to the public internet gateway routing table.
  - Optionally add an egress-only internet gateway and IPv6 route for egress traffic.
- Added IPv6 support to the `cloudflare-sg` module