### PR TITLE
Release 8.10.1 -- Fix private_ipv6 route plan issue

### DIFF
--- a/aws/vpc/main.tf
+++ b/aws/vpc/main.tf
@@ -90,7 +90,7 @@ resource "aws_route" "private_ipv6" {
 
   route_table_id              = aws_route_table.private_route_table.id
   destination_ipv6_cidr_block = "::/0"
-  gateway_id                  = one(aws_egress_only_internet_gateway.ipv6[*].id)
+  egress_only_gateway_id      = one(aws_egress_only_internet_gateway.ipv6[*].id)
 }
 
 


### PR DESCRIPTION
### Fixed
- In `vpc` module, change `aws_route.private_ipv6` to use `egress_only_gateway_id` rather than `gateway_id`. This should resolve an issue where every plan wants to remove an `egress_only_gateway_id` value and add a `gateway_id` value.
