### PR TITLE
Release 8.11.0 -- add IPv6 support to the asg and alb modules

### DIFF
--- a/aws/alb/README.md
+++ b/aws/alb/README.md
@@ -30,6 +30,7 @@ groups for traffic and a default target group.
  - `health_check_status_codes` - Default: `200`, separate multiple values with comma, ex: `200,204`
  - `idle_timeout` - Default: `60`
  - `load_balancer_type` - Options: `application` or `network`. Default: `application`
+ - `enable_ipv6` - Set to `true` to enable IPv6. Changes the ALB `ip_address_type` to `"dualstack"`. Default: `false`
 
 ## Outputs
 

--- a/aws/alb/main.tf
+++ b/aws/alb/main.tf
@@ -8,6 +8,7 @@ resource "aws_alb" "alb" {
   subnets            = var.subnets
   load_balancer_type = var.load_balancer_type
   idle_timeout       = var.idle_timeout
+  ip_address_type    = var.enable_ipv6 ? "dualstack" : "ipv4"
 
   tags = {
     Name     = coalesce(var.alb_name, "alb-${var.app_name}-${var.app_env}")

--- a/aws/alb/vars.tf
+++ b/aws/alb/vars.tf
@@ -100,3 +100,8 @@ variable "load_balancer_type" {
   default = "application"
 }
 
+variable "enable_ipv6" {
+  description = "Set to `true` to enable IPv6. Changes the ALB `ip_address_type` to `"dualstack"`."
+  type        = bool
+  default     = false
+}

--- a/aws/asg/README.md
+++ b/aws/asg/README.md
@@ -27,6 +27,7 @@ an auto scaling group that uses the template.
  - `additional_user_data` - command to append to the EC2 user\_data, default is ""
  - `tags` - Map of tags to be added to all resources, including the network-interface and volume created by the launch template. The `propagate_at_launch` flag will be set true for all tags.
  - `cpu_credits` - Value for the `credit_specification` if you want to override the AWS default for `aws_launch_template`.
+ - `enable_ipv6` - Set to true to add an IPv6 IP address to ASG-created instances. Default: `false`
 
 ## Outputs
 

--- a/aws/asg/main.tf
+++ b/aws/asg/main.tf
@@ -40,6 +40,7 @@ resource "aws_launch_template" "asg_lt" {
   network_interfaces {
     associate_public_ip_address = var.associate_public_ip_address
     security_groups             = concat([var.default_sg_id], var.additional_security_groups)
+    ipv6_address_count          = var.enable_ipv6 ? 1 : 0
   }
 
   iam_instance_profile {

--- a/aws/asg/vars.tf
+++ b/aws/asg/vars.tf
@@ -79,3 +79,9 @@ variable "tags" {
   description = "Map of tags to be added to all resources, including the network-interface and volume created by the launch template"
   default     = {}
 }
+
+variable "enable_ipv6" {
+  description = "set to true to add an IPv6 IP address to ASG-created instances"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
### Added
- Added `enable_ipv6` inputs to the asg and alb modules.
  - `alb`: Changes `ip_address_type` to `"dualstack"`.
  - `asg`: Sets `ipv6_address_count` to `1`.