### PR TITLE
Output the name of the created IAM user with access to the S3 bucket

### DIFF
--- a/aws/cloudtrail/README.md
+++ b/aws/cloudtrail/README.md
@@ -18,7 +18,8 @@ This module is used to set up CloudTrail logging for your AWS account.
 
 ## Outputs
 
-_none_
+- `s3_bucket_iam_user_name` - The name of the created IAM user that has access to the S3 bucket,
+  which is needed if you want to create an IAM access key (external to this module).
 
 ## Example Usage
 

--- a/aws/cloudtrail/outputs.tf
+++ b/aws/cloudtrail/outputs.tf
@@ -1,0 +1,3 @@
+output "s3_bucket_iam_user_name" {
+  value = aws_iam_user.cloudtrail-s3.name
+}


### PR DESCRIPTION
### Added
- Output the name of the created IAM user with access to the S3 bucket that CloudTrail logs are stored in