### PR TITLE
Release 8.13.0 -- Update to AWS provider version 5

### DIFF
--- a/aws/alb/versions.tf
+++ b/aws/alb/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0, < 5.0.0"
+      version = ">= 4.0.0, < 6.0.0"
     }
   }
 }

--- a/aws/asg-ebs/versions.tf
+++ b/aws/asg-ebs/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0, < 5.0.0"
+      version = ">= 4.0.0, < 6.0.0"
     }
   }
 }

--- a/aws/asg/versions.tf
+++ b/aws/asg/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0, < 5.0.0"
+      version = ">= 4.0.0, < 6.0.0"
     }
   }
 }

--- a/aws/backup/rds/versions.tf
+++ b/aws/backup/rds/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0, < 5.0.0"
+      version = ">= 4.0.0, < 6.0.0"
     }
   }
 }

--- a/aws/cloudflare-sg/versions.tf
+++ b/aws/cloudflare-sg/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0, < 5.0.0"
+      version = ">= 4.0.0, < 6.0.0"
     }
   }
 }

--- a/aws/cloudtrail/versions.tf
+++ b/aws/cloudtrail/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0, < 5.0.0"
+      version = ">= 4.0.0, < 6.0.0"
     }
   }
 }

--- a/aws/ecr/versions.tf
+++ b/aws/ecr/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0, < 5.0.0"
+      version = ">= 4.0.0, < 6.0.0"
     }
   }
 }

--- a/aws/ecs/cluster/versions.tf
+++ b/aws/ecs/cluster/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0, < 5.0.0"
+      version = ">= 4.0.0, < 6.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/aws/ecs/service-no-alb-with-volume/versions.tf
+++ b/aws/ecs/service-no-alb-with-volume/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0, < 5.0.0"
+      version = ">= 4.0.0, < 6.0.0"
     }
   }
 }

--- a/aws/ecs/service-no-alb/versions.tf
+++ b/aws/ecs/service-no-alb/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0, < 5.0.0"
+      version = ">= 4.0.0, < 6.0.0"
     }
   }
 }

--- a/aws/ecs/service-only-with-volume/versions.tf
+++ b/aws/ecs/service-only-with-volume/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0, < 5.0.0"
+      version = ">= 4.0.0, < 6.0.0"
     }
   }
 }

--- a/aws/ecs/service-only/versions.tf
+++ b/aws/ecs/service-only/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0, < 5.0.0"
+      version = ">= 4.0.0, < 6.0.0"
     }
   }
 }

--- a/aws/elasticache/memcache/versions.tf
+++ b/aws/elasticache/memcache/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0, < 5.0.0"
+      version = ">= 4.0.0, < 6.0.0"
     }
   }
 }

--- a/aws/elasticache/redis/versions.tf
+++ b/aws/elasticache/redis/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0, < 5.0.0"
+      version = ">= 4.0.0, < 6.0.0"
     }
   }
 }

--- a/aws/rds/mariadb/versions.tf
+++ b/aws/rds/mariadb/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0, < 5.0.0"
+      version = ">= 4.0.0, < 6.0.0"
     }
   }
 }

--- a/cloudflare/ips/versions.tf
+++ b/cloudflare/ips/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0, < 5.0.0"
+      version = ">= 4.0.0, < 6.0.0"
     }
     http = {
       source  = "hashicorp/http"

--- a/test/.terraform.lock.hcl
+++ b/test/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.67.0"
-  constraints = ">= 4.0.0, < 5.0.0"
+  constraints = ">= 4.0.0, < 6.0.0"
   hashes = [
     "h1:dCRc4GqsyfqHEMjgtlM1EympBcgTmcTkWaJmtd91+KA=",
     "zh:0843017ecc24385f2b45f2c5fce79dc25b258e50d516877b3affee3bef34f060",


### PR DESCRIPTION
### Added
- Added support for AWS provider version 5 in all modules except `vpc`. (The `vpc` module uses the `vpc` parameter, which is deprecated in version 4 and removed from version 5.)