### PR TITLE
Release 8.13.1 -- simplify cloudflare-sg and update AWS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @silinternational/tf-devs

--- a/aws/cloudflare-sg/main.tf
+++ b/aws/cloudflare-sg/main.tf
@@ -1,6 +1,3 @@
-module "cf_ips" {
-  source = "github.com/silinternational/terraform-modules//cloudflare/ips?ref=6.0.0"
-}
 
 resource "aws_security_group" "cloudflare_https" {
   name        = "cloudflare-https"
@@ -14,6 +11,14 @@ resource "aws_security_group_rule" "cloudflare_ipv4" {
   to_port           = 443
   protocol          = "tcp"
   security_group_id = aws_security_group.cloudflare_https.id
-  cidr_blocks       = module.cf_ips.ipv4_cidrs
-  ipv6_cidr_blocks  = module.cf_ips.ipv6_cidrs
+  cidr_blocks       = split("\n", trimspace(data.http.cloudflare_ipv4.response_body))
+  ipv6_cidr_blocks  = split("\n", trimspace(data.http.cloudflare_ipv6.response_body))
+}
+
+data "http" "cloudflare_ipv4" {
+  url = "https://www.cloudflare.com/ips-v4"
+}
+
+data "http" "cloudflare_ipv6" {
+  url = "https://www.cloudflare.com/ips-v6"
 }

--- a/aws/cloudflare-sg/versions.tf
+++ b/aws/cloudflare-sg/versions.tf
@@ -7,5 +7,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 4.0.0, < 6.0.0"
     }
+    http = {
+      source  = "hashicorp/http"
+      version = ">= 2.0.0, < 3.0.0"
+    }
   }
 }


### PR DESCRIPTION
### Changed
- Move cloudflare/ips into cloudflare-sg to get AWS updated