### PR TITLE
Release 8.13.2 -- rename cloudflare security group rule to account for ipv6

### DIFF
--- a/aws/cloudflare-sg/main.tf
+++ b/aws/cloudflare-sg/main.tf
@@ -5,7 +5,7 @@ resource "aws_security_group" "cloudflare_https" {
   vpc_id      = var.vpc_id
 }
 
-resource "aws_security_group_rule" "cloudflare_ipv4" {
+resource "aws_security_group_rule" "cloudflare" {
   type              = "ingress"
   from_port         = 443
   to_port           = 443
@@ -13,6 +13,11 @@ resource "aws_security_group_rule" "cloudflare_ipv4" {
   security_group_id = aws_security_group.cloudflare_https.id
   cidr_blocks       = split("\n", trimspace(data.http.cloudflare_ipv4.response_body))
   ipv6_cidr_blocks  = split("\n", trimspace(data.http.cloudflare_ipv6.response_body))
+}
+
+moved {
+  from = aws_security_group_rule.cloudflare_ipv4
+  to   = aws_security_group_rule.cloudflare
 }
 
 data "http" "cloudflare_ipv4" {


### PR DESCRIPTION
### Changed
- Rename the Cloudflare security group rule to remove the "ipv4" since it now contains IPv6 addresses.