### PR TITLE
Release 8.13.3 -- require Terraform 1.1 for cloudflare-sg

### DIFF
--- a/aws/cloudflare-sg/versions.tf
+++ b/aws/cloudflare-sg/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 1.1"
 
   required_providers {
     aws = {


### PR DESCRIPTION
### Fixed
- cloudflare-sg requires Terraform 1.1 because of a "moved" block